### PR TITLE
add usage and examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,177 @@
+# dry-monads
+
+Monads for Ruby.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'dry-monads'
+```
+
+And then execute:
+
+```sh
+$ bundle
+```
+
+Or install it yourself as:
+
+```sh
+$ gem install dry-monads
+```
+
+## Usage
+
+### Maybe monad
+
+The `Maybe` mondad is used when a series of computations that could return `nil`
+at any point.
+
+#### `>>` or `bind`
+
+```
+require 'dry/monads'
+
+maybe_user = Dry::Monads::Maybe(user) >> -> (u) {
+  Dry::Monads::Maybe(user.address) >> -> (a) {
+    Dry::Monads::Maybe(a.street)
+  }
+}
+
+# If user with address exists
+# => Some("Street Address")
+# If user or address is nil
+# => None()
+```
+
+#### `fmap`
+
+```
+require 'dry/monads'
+
+Dry::Monads::Maybe(user).fmap(&:address).fmap(&:street)
+
+# If user with address exists
+# => Some("Street Address")
+# If user or address is nil
+# => None()
+```
+
+### Either monad
+
+The `Either` mondad is useful to express a series of computations that might
+return an error object with additional information.
+
+The `Either` mixin has two type constructors: `Right` and `Left`. The `Right`
+can be thought of as "everything went right" and the `Left` is used when
+"something has gone wrong".
+
+#### `Either::Mixin`
+
+```
+require 'dry/monads'
+
+class EitherCalculator
+  include Dry::Monads::Either::Mixin
+
+  attr_accessor :input
+
+  def calculate
+    i = input.to_i
+    Right(i) >> -> (value) {
+      if value > 1
+        Right(value + 3)
+      else
+        Left("value was less than 1")
+      end
+    } >> -> (value) {
+      if value % 2 == 0
+        Right(value * 2)
+      else
+        Left("value was not even")
+      end
+    }
+  end
+end
+
+# EitherCalculator instance
+c = EitherCalculator.new
+
+# If everything went right
+c.input = 3
+result = c.calculate
+result # => Right(12)
+result.value # => 12
+
+# If if failed in the first proc
+c.input = 0
+result = c.calculate
+result # => Left("value was less than 1")
+result.value # => "value was less than 1"
+
+# if it failed in the second proc
+c.input = 2
+result = c.calculate
+result # => Left("value was not even")
+result.value # => "value was not even"
+```
+
+#### `fmap`
+
+An exmple of using `fmap` with `Right` and `Left`.
+
+```
+require 'dry/monads'
+
+result = if foo > bar
+  Dry::Monads::Right(10)
+else
+  Dry::Monads::Left("wrong")
+end.fmap { |x| x * 2 }
+
+# If everything went right
+result # => Right(20)
+# If it did not
+result # => Left("wrong")
+```
+
+#### `or`
+
+An example of using `or` with `Right` and `Left`.
+
+```
+Dry::Monads::Right(10).or(Dry::Monads::Right(99)) # => Right(10)
+Dry::Monads::Left("error").or(Dry::Monads::Left("new error")) # => Left("new error")
+Dry::Monads::Left("error").or { |err| Dry::Monads::Left("new #{err}") } # => Left("new error")
+```
+
+#### `to_maybe`
+
+Sometimes it's usefule to turn an 'Either' into a 'Maybe'
+
+```
+require 'dry/monads'
+
+result = if foo > bar
+  Dry::Monads::Right(10)
+else
+  Dry::Monads::Left("wrong")
+end.to_maybe
+
+# If everything went right
+result # => Some(10)
+# If it did not
+result # => None()
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at [https://github.com/dry-rb/dry-monads]().

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "dry/monads"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,3 +1,6 @@
+require 'dry/monads/either'
+require 'dry/monads/maybe'
+
 module Dry
   module Monads
     def self.Maybe(value)

--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -51,6 +51,7 @@ module Dry
         def bind(proc = nil)
           self
         end
+        alias_method :>>, :bind
 
         def fmap
           self

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -55,6 +55,7 @@ module Dry
         def bind(proc = nil)
           self
         end
+        alias_method :>>, :bind
 
         def fmap
           self


### PR DESCRIPTION
Added a basic usage and examples to the README.md. I got lazy at the end and copied most of the examples from the Kleisli project. There doesn't appear to be a standard for README formats with the dry-* gems and not really sure how important it is for this gem's README to differ from Kleisli. Anyways it's a start and feel free to make any modifications.