### PR TITLE
Add Dry::Monads::Try

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ at any point.
 
 #### `bind` or `>>`
 
-```
-require 'dry/monads'
+```ruby
+require 'dry-monads'
 
 M = Dry::Monads
 
@@ -62,8 +62,8 @@ M.Maybe >> :succ.to_proc >> add_two # => Some(8)
 
 Similar to `bind` but lifts the result for you.
 
-```
-require 'dry/monads'
+```ruby
+require 'dry-monads'
 
 Dry::Monads::Maybe(user).fmap(&:address).fmap(&:street)
 
@@ -84,8 +84,8 @@ can be thought of as "everything went right" and the `Left` is used when
 
 #### `Either::Mixin`
 
-```
-require 'dry/monads'
+```ruby
+require 'dry-monads'
 
 class EitherCalculator
   include Dry::Monads::Either::Mixin
@@ -137,13 +137,15 @@ result.value # => "value was not even"
 
 An example of using `fmap` with `Right` and `Left`.
 
-```
-require 'dry/monads'
+```ruby
+require 'dry-monads'
+
+M = Dry::Monads
 
 result = if foo > bar
-  Dry::Monads.Right(10)
+  M.Right(10)
 else
-  Dry::Monads.Left("wrong")
+  M.Left("wrong")
 end.fmap { |x| x * 2 }
 
 # If everything went right
@@ -153,16 +155,16 @@ result # => Left("wrong")
 
 # #fmap accepts proc as well as #bind
 
-upcase = s:upcase.to_proc
+upcase = :upcase.to_proc
 
-Right('hello').fmap(upcase) # => Right("HELLO")
+M.Right('hello').fmap(upcase) # => Right("HELLO")
 ```
 
 #### `or`
 
 An example of using `or` with `Right` and `Left`.
 
-```
+```ruby
 M = Dry::Monads
 
 M.Right(10).or(M.Right(99)) # => Right(10)
@@ -174,8 +176,8 @@ M.Left("error").or { |err| M.Left("new #{err}") } # => Left("new error")
 
 Sometimes it's useful to turn an 'Either' into a 'Maybe'
 
-```
-require 'dry/monads'
+```ruby
+require 'dry-monads'
 
 result = if foo > bar
   Dry::Monads.Right(10)
@@ -187,6 +189,27 @@ end.to_maybe
 result # => Some(10)
 # If it did not
 result # => None()
+```
+
+### Try monad
+
+Examples of using the `Try` monad.
+
+```ruby
+require 'dry-monads'
+
+extend Dry::Monads::Try::Mixin
+
+res = Try() { 10 / 2 }
+res.value if res.success?
+# => 5
+
+res = Try() { 10 / 0 }
+res.exception if res.failure?
+# => #<ZeroDivisionError: divided by 0>
+
+Try(NoMethodError, NotImplementedError) { 10 / 0 }
+# => raise ZeroDivisionError: divided by 0 exception
 ```
 
 ## Development

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'dry/monads'
+require 'dry-monads'
 
 M = Dry::Monads
 

--- a/dry-monads.gemspec
+++ b/dry-monads.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['fg@flashgordon.ru']
   spec.license       = 'MIT'
 
-  spec.summary       = ''
+  spec.summary       = 'Common monads for Ruby.'
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/dry-rb/dry-monads'
 

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,5 +1,6 @@
 require 'dry/monads/either'
 require 'dry/monads/maybe'
+require 'dry/monads/try'
 
 module Dry
   module Monads

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -1,0 +1,79 @@
+module Dry
+  module Monads
+    class Try
+      attr_reader :exception, :value
+
+      def self.lift(exceptions, f)
+        Success.new(exceptions, f.call)
+      rescue *exceptions => e
+        Failure.new(e)
+      end
+
+      def success?
+        is_a? Success
+      end
+
+      def failure?
+        is_a? Failure
+      end
+
+      class Success < Try
+        def initialize(exceptions, value)
+          @catchable = exceptions
+          @value = value
+        end
+
+        def bind(f)
+          f.call(@value)
+        rescue => e
+          Failure.new(e)
+        end
+        alias_method :>>, :bind
+
+        def fmap(&f)
+          Try.lift @catchable, -> { f.call(@value) }
+        end
+
+        def to_maybe
+          Dry::Monads::Maybe(@value)
+        end
+
+        def to_either
+          Dry::Monads::Right(@value)
+        end
+      end
+
+      class Failure < Try
+        def initialize(exception)
+          @exception = exception
+        end
+
+        def bind(f)
+          self
+        end
+        alias_method :>>, :bind
+
+        def fmap(&f)
+          self
+        end
+
+        def to_maybe
+          Dry::Monads::None()
+        end
+
+        def to_either
+          Dry::Monads::Left(@exception)
+        end
+      end
+
+      module Mixin
+        Try = Try
+
+        def Try(*exceptions, &f)
+          catchable = exceptions.any? ? exceptions.flatten : [StandardError]
+          Try.lift(catchable, f)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/try_spec.rb
+++ b/spec/integration/try_spec.rb
@@ -1,0 +1,131 @@
+RSpec.describe(Dry::Monads::Try) do
+  include Dry::Monads::Try::Mixin
+
+  context 'success' do
+    let(:try) { Try { 10 / 2 } }
+
+    example do
+      aggregate_failures do
+        expect(try).to be_kind_of(Dry::Monads::Try::Success)
+        expect(try.success?).to eq(true)
+        expect(try.failure?).to eq(false)
+      end
+    end
+  end
+
+  context 'failure' do
+    let(:try) { Try { 10 / 0 } }
+
+    example do
+      aggregate_failures do
+        expect(try).to be_kind_of(Dry::Monads::Try::Failure)
+        expect(try.success?).to eq(false)
+        expect(try.failure?).to eq(true)
+      end
+    end
+  end
+
+  context 'success value' do
+    let(:try) { Try { 10 / 2 } }
+
+    example do
+      expect(try.value).to eq(5)
+    end
+  end
+
+  context 'failure exception' do
+    let(:try) { Try { 10 / 0 } }
+
+    example do
+      expect(try.exception).to be_kind_of(ZeroDivisionError)
+    end
+  end
+
+  context 'bind success' do
+    let(:try) { Try { 20 / 10 } >> -> (number) { Try { 10 / number } } }
+
+    example do
+      expect(try.value).to eq(5)
+    end
+  end
+
+  context 'bind failure' do
+    let(:try) { Try { 20 / 0 } >> -> (number) { Try { 10 / number } } }
+
+    example do
+      expect(try.exception).to be_kind_of(ZeroDivisionError)
+    end
+  end
+
+  context 'fmap success' do
+    let(:try) { Try { 10 / 5 }.fmap { |x| x * 2 } }
+
+    example do
+      expect(try.value).to eq(4)
+    end
+  end
+
+  context 'fmap failure' do
+    let(:try) { Try { 10 / 0 }.fmap { |x| x * 2 } }
+
+    example do
+      expect(try.exception).to be_kind_of(ZeroDivisionError)
+    end
+  end
+
+  context 'to maybe success' do
+    let(:try) { Try { 10 / 5 }.to_maybe }
+
+    example do
+      expect(try).to eq(Dry::Monads::Some(2))
+    end
+  end
+
+  context 'to maybe failure' do
+    let(:try) { Try { 10 / 0 }.to_maybe }
+
+    example do
+      expect(try).to eq(Dry::Monads::None())
+    end
+  end
+
+  context 'to either success' do
+    let(:try) { Try { 10 / 5 }.to_either }
+
+    example do
+      expect(try).to eq(Dry::Monads::Right(2))
+    end
+  end
+
+  context 'to either failure' do
+    let(:try) { Try { 10 / 0 }.to_either }
+
+    example do
+      aggregate_failures do
+        expect(try).to be_kind_of(Dry::Monads::Either::Left)
+        expect(try.value).to be_kind_of(ZeroDivisionError)
+      end
+    end
+  end
+
+  context 'no exceptions raised when in a list of catchable exceptions' do
+    let(:try) { Try(NoMethodError, NotImplementedError) { raise NotImplementedError } }
+
+    example do
+      aggregate_failures do
+        expect(try).to be_kind_of(Dry::Monads::Try::Failure)
+        expect(try.exception).to be_kind_of(NotImplementedError)
+      end
+    end
+  end
+
+  context 'exception raised if not within a list of catchable exceptions' do
+    let(:try) { Try(NoMethodError, NotImplementedError) { 10 / 0 } }
+
+    example do
+      aggregate_failures do
+        expect{ try }.to raise_error(ZeroDivisionError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is mostly what I am personally interested in using. Hopefully it has a place within the `dry-monads` gem. I'm not entirely certain if the `fmap` method is correct for `Dry::Monads::Try::Success` - it passes specs but maybe there is a better way of implementing that method without the extra proc.