### PR TITLE
Add '#success?' and '#failure?' to Either (same as Try)

### DIFF
--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -7,6 +7,14 @@ module Dry
         other.is_a?(Either) && right == other.right && left == other.left
       end
 
+      def success?
+        is_a? Right
+      end
+
+      def failure?
+        is_a? Left
+      end
+
       class Right < Either
         alias value right
 

--- a/spec/integration/either_spec.rb
+++ b/spec/integration/either_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe(Dry::Monads::Either) do
   context 'going happy path' do
     let(:right) { Right(message: 'success') }
 
+    it { expect(right.success?).to eq(true) }
+    it { expect(right.failure?).to eq(false) }
+
     context 'using map' do
       example 'with block' do
         result = right.fmap do |message: |
@@ -40,6 +43,9 @@ RSpec.describe(Dry::Monads::Either) do
 
   context 'going unhappy path' do
     let(:left) { Left(error: 'failure') }
+
+    it { expect(left.success?).to eq(false) }
+    it { expect(left.failure?).to eq(true) }
 
     example 'with block' do
       result = left.or do |error: |


### PR DESCRIPTION
Add convenience methods of `#success?` and `#failure?` to `Either`. Same implementation as `Try` where they check if the object is an instance of `Right` or `Left`. Useful if binding together a chain of monads and you wanted to check the result. Ideally the `dry-result_matcher` would be updated to use these methods new methods - then it could support `Either` or `Try`.