### PR TITLE
Add #right? and #left? to Either (alias #success? and #failure?)

### DIFF
--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -7,13 +7,15 @@ module Dry
         other.is_a?(Either) && right == other.right && left == other.left
       end
 
-      def success?
+      def right?
         is_a? Right
       end
+      alias success? right?
 
-      def failure?
+      def left?
         is_a? Left
       end
+      alias failure? left?
 
       class Right < Either
         alias value right

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe(Dry::Monads::Either) do
 
     let(:upcased_subject) { either::Right.new('FOO') }
 
+    it { is_expected.to be_right }
     it { is_expected.to be_success }
+
+    it { is_expected.not_to be_left }
     it { is_expected.not_to be_failure }
 
     it { is_expected.to eq(described_class.new('foo')) }
@@ -68,7 +71,10 @@ RSpec.describe(Dry::Monads::Either) do
   describe either::Left do
     subject { either::Left.new('bar') }
 
+    it { is_expected.not_to be_right }
     it { is_expected.not_to be_success }
+
+    it { is_expected.to be_left }
     it { is_expected.to be_failure }
 
     it { is_expected.to eq(described_class.new('bar')) }


### PR DESCRIPTION
@timriley Is this a better option for an interface to `Either`? I still would like to alias the `#success?` and `#failure?` even though you are right that it does not necessarily imply the a "success" or "failure". I could see how they might be used in the `dry-result_matcher` gem.