### PR TITLE
Add Either#to_either

### DIFF
--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -17,6 +17,10 @@ module Dry
       end
       alias failure? left?
 
+      def to_either
+        self
+      end
+
       class Right < Either
         alias value right
 

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe(Dry::Monads::Either) do
       end
     end
 
+    describe '#to_either' do
+      let(:subject) { either::Right.new('foo').to_either }
+
+      it 'returns self' do
+        is_expected.to eq(either::Right.new('foo'))
+      end
+    end
+
     describe '#to_maybe' do
       let(:subject) { either::Right.new('foo').to_maybe }
 


### PR DESCRIPTION
This makes it easy to consume any type of monad object that is convertible to Either, including Either objects themselves.

More practically speaking, when we’re working with objects from dry-monads, we can just call `#to_either` on it without checking for a `respond_to?`.

This helps make our matching in dry-result_matcher more straightforward. This is what we're doing in there now: https://github.com/dry-rb/dry-result_matcher/pull/6/files#diff-d56dbbac02a272f262c46ad4bdbdcbf4R8

And some related discussion: https://github.com/dry-rb/dry-result_matcher/pull/6#discussion_r68852351