### PR TITLE
Fix rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,17 @@ Style/MultilineBlockChain:
 Style/GuardClause:
   Enabled: false
 
+Style/SymbolProc:
+  Exclude:
+    # This rule is broken in specs on purpose to make examples clearer
+    - 'spec/**/*'
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/RescueModifier:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 110
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 sudo: false
 cache: bundler
-bundler_args: --without benchmarks tools
+bundler_args: --without benchmarks
 script:
   - bundle exec rake spec
+  - bundle exec rubocop
 rvm:
   - 2.0
   - 2.1

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ prompt that will allow you to experiment.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at [https://github.com/dry-rb/dry-monads]().
+Bug reports and pull requests are welcome on GitHub at <https://github.com/dry-rb/dry-monads>.

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -166,7 +166,6 @@ module Dry
           Some.new(value)
         end
 
-        # @param value [Object] the value to be stored in the monad
         # @return [Maybe::None]
         def None
           None.instance

--- a/spec/integration/either_spec.rb
+++ b/spec/integration/either_spec.rb
@@ -108,9 +108,7 @@ RSpec.describe(Dry::Monads::Either) do
       result = right.fmap do |r|
         { value: r[:value] + 1 }
       end.bind do |r|
-        if r[:value] > 0
-          Right(value: r[:value] + 1)
-        end
+        Right(value: r[:value] + 1) if r[:value] > 0
       end.or do
         Left('error')
       end

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe(Dry::Monads::Try) do
   no_method_error = no_method rescue $ERROR_INFO
 
   let(:upcase) { :upcase.to_proc }
-  let(:divide_by_zero) { -> (_value) { raise division_error }  }
+  let(:divide_by_zero) { -> (_value) { raise division_error } }
 
   describe(try::Success) do
     subject { described_class.new([ZeroDivisionError], 'foo') }


### PR DESCRIPTION
This commit fixes some rubocop offenses, updates configs to match the
 wanted code style and adds rubocop to the travis script.

It also includes 2 small improvements not detected by rubocop:
   - The link in readme at the bottom is being incorrectly
      rendered by Github, this should fix the issue.
   - A superfluous YARD comment was removed.