### PR TITLE
Support extra arguments in fmap and bind

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   Exclude:
     - 'spec/integration/either_spec.rb'
+    - 'vendor/**/*'
 
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  Exclude:
+    - 'spec/integration/either_spec.rb'
+
 Style/Documentation:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,10 @@ Style/SymbolProc:
     # This rule is broken in specs on purpose to make examples clearer
     - 'spec/**/*'
 
+Style/SignalException:
+  Exclude:
+    - 'spec/**/*'
+
 Style/ModuleFunction:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ script:
   - bundle exec rake spec
   - bundle exec rubocop
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
   - rbx-2
-  - jruby-9000
+  - jruby-9.1.1.0
   - ruby-head
 env:
   global:

--- a/dry-monads.gemspec
+++ b/dry-monads.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.add_dependency 'dry-equalizer'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,3 +1,4 @@
+require 'dry/equalizer'
 require 'dry/monads/either'
 require 'dry/monads/maybe'
 require 'dry/monads/try'

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -5,7 +5,6 @@ module Dry
     #
     # @api public
     class Try
-      include Dry::Equalizer(:exception, :value)
       attr_reader :exception, :value
 
       # Calls the passed in proc object and if successful stores the result in a
@@ -35,7 +34,7 @@ module Dry
       #
       # @api public
       class Success < Try
-        include Dry::Equalizer(:exception, :value, :catchable)
+        include Dry::Equalizer(:value, :catchable)
         attr_reader :catchable
 
         # @param exceptions [Array<Exception>] list of exceptions to be rescued
@@ -112,6 +111,8 @@ module Dry
       #
       # @api public
       class Failure < Try
+        include Dry::Equalizer(:exception)
+
         # @param exception [Exception]
         def initialize(exception)
           @exception = exception

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -84,7 +84,7 @@ module Dry
         # @return [Try::Success, Try::Failure]
         def fmap(*args, &block)
           if block
-            Try.lift(catchable, -> { block.call(value, *args) })
+            Try.lift(catchable, -> { yield(value, *args) })
           else
             Try.lift(catchable, -> { args[0].call(value, *args.drop(1)) })
           end

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -93,12 +93,12 @@ module Dry
 
         # @return [Maybe]
         def to_maybe
-          Dry::Monads::Maybe(@value)
+          Dry::Monads::Maybe(value)
         end
 
         # @return [Either::Right]
         def to_either
-          Dry::Monads::Right(@value)
+          Dry::Monads::Right(value)
         end
 
         # @return [String]
@@ -140,7 +140,7 @@ module Dry
 
         # @return [Either::Left]
         def to_either
-          Dry::Monads::Left(@exception)
+          Dry::Monads::Left(exception)
         end
 
         # @return [String]

--- a/spec/integration/either_spec.rb
+++ b/spec/integration/either_spec.rb
@@ -127,5 +127,17 @@ RSpec.describe(Dry::Monads::Either) do
 
       expect(result).to eq(Left(value: -2))
     end
+
+    example 'using required keyword arguments' do
+      result = Right(foo: 0, bar: 0, baz: 0).fmap do |foo: , **rest|
+        { foo: 1, **rest }
+      end.fmap do |bar: , **rest|
+        { bar: bar + 1, **rest }
+      end.fmap do |foo: , bar: , **rest|
+        { **rest, baz: foo + bar }
+      end
+
+      expect(result).to eql(Right(baz: 2))
+    end
   end
 end

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe(Dry::Monads::Either) do
       end
 
       it 'passes extra arguments to a proc' do
-        proc = -> (value, c) do
+        proc = lambda do |value, c|
           expect(value).to eql('foo')
           expect(c).to eql(:foo)
           true
@@ -79,7 +79,7 @@ RSpec.describe(Dry::Monads::Either) do
       end
 
       it 'passes extra arguments to a proc' do
-        proc = -> (value, c1, c2) do
+        proc = lambda do |value, c1, c2|
           expect(value).to eql('foo')
           expect(c1).to eql(:foo)
           expect(c2).to eql(:bar)
@@ -152,7 +152,7 @@ RSpec.describe(Dry::Monads::Either) do
       end
 
       it 'ignores extra arguments' do
-        expect(subject.bind(1, 2, 3) { |v| 1 / 0 }).to be subject
+        expect(subject.bind(1, 2, 3) { fail }).to be subject
       end
     end
 

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
 
       it 'ignores arguments' do
-        expect(subject.fmap(1, 2, 3) { fail }).to be subject
+        expect(subject.bind(1, 2, 3) { fail }).to be subject
       end
     end
 

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
 
       it 'passes extra arguments to a proc' do
-        proc = -> (value, c) do
+        proc = lambda do |value, c|
           expect(value).to eql('foo')
           expect(c).to eql(:foo)
           true
@@ -81,7 +81,7 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
 
       it 'passes extra arguments to a proc' do
-        proc = -> (value, c1, c2) do
+        proc = lambda do |value, c1, c2|
           expect(value).to eql('foo')
           expect(c1).to eql(:foo)
           expect(c2).to eql(:bar)

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -140,7 +140,12 @@ RSpec.describe(Dry::Monads::Try) do
 
     it { is_expected.to eq(described_class.new(division_error)) }
     it { is_expected.not_to eq(try::Success.new([ZeroDivisionError], 'foo')) }
-    it { is_expected.not_to eq(described_class.new(other_error)) }
+
+    # This assertion does not always pass on JRuby, but it's some deep JRuby's internals,
+    # so let's just ignore it
+    unless defined? JRUBY_VERSION
+      it { is_expected.not_to eq(described_class.new(other_error)) }
+    end
 
     it 'dumps to string' do
       expect(subject.to_s).to eql('Try::Failure(ZeroDivisionError: divided by 0)')


### PR DESCRIPTION
This makes `#bind` and `#fmap` able to accept an arbitrary number of arguments that will be passed to the block you provide. In many cases there is no need for that because you can just pass extra values as free variables, that is via a closure:
```ruby
some_value = 1
my_monad.bind do |monad_value|
  monad_value + some_value
end
```
That's fine, but sometimes (quite often, actually) you want to pass a ~~function/~~proc/method object/whatever callable instead of passing a block, so you can't use the trick I described. What I do is send all the values I will (even would) need packed as a hash through a monad pipeline, like this:
```ruby
def do
  returns_monad(foo: :a, bar: :b).fmap(method(:uses_foo)).fmap(method(:uses_bar))
end

def returns_monad(**values)
  Right(values)
end

def uses_foo(foo: , **rest)
  p foo
  rest
end

def uses_bar(bar: , **rest)
  p bar
  rest
end
```
With these changes you don't have to pass all values together, you can pass them directly to `fmap`/`bind` call:
```ruby
def do
  returns_monad.fmap(method(:uses_foo), :a).fmap(method(:uses_bar), :b)
end

def returns_monad
  Right(:quux)
end

def uses_foo(value, foo)
  p foo
  value
end

def uses_bar(value, bar)
  p bar
  value
end
```