### PR TITLE
`#or` should return strict value instead of Some(value) for ::Some

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -84,12 +84,12 @@ module Dry
           self.class.lift(bind(*args, &block))
         end
 
-        # Ignores arguments and returns self. It exists to keep the interface
+        # Ignores arguments and returns value. It exists to keep the interface
         # identical to that of {Maybe::None}.
         #
-        # @return [Maybe::Some]
+        # @return [Object]
         def or(*)
-          self
+          value
         end
 
         # @return [String]

--- a/spec/integration/maybe_spec.rb
+++ b/spec/integration/maybe_spec.rb
@@ -72,11 +72,11 @@ RSpec.describe(Dry::Monads::Maybe) do
 
     context 'going happy' do
       example 'using lambda with lifting' do
-        expect(some.fmap(inc).fmap(inc).fmap(inc).or(0)).to eql(Some(6))
+        expect(some.fmap(inc).fmap(inc).fmap(inc).or(0)).to eql(6)
       end
 
       example 'using lambda without lifting' do
-        expect(some.bind(&maybe_inc).bind { |x| maybe_inc[x] }.or(0)).to eql(Some(5))
+        expect(some.bind(&maybe_inc).bind { |x| maybe_inc[x] }.or(0)).to eql(5)
       end
 
       example 'using block' do
@@ -84,7 +84,7 @@ RSpec.describe(Dry::Monads::Maybe) do
           Some(inc[x])
         end.or(0)
 
-        expect(result).to eql(Some(4))
+        expect(result).to eql(4)
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
 
       example 'using values in a long chain' do
-        expect(none.fmap(inc).or(Some(7).or(0))).to eql(Some(7))
+        expect(none.fmap(inc).or(Some(7).or(0))).to eql(7)
       end
 
       example 'using block' do

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -96,15 +96,15 @@ RSpec.describe(Dry::Monads::Maybe) do
 
     describe '#or' do
       it 'accepts a value as an alternative' do
-        expect(subject.or('baz')).to be(subject)
+        expect(subject.or('baz')).to be(subject.value)
       end
 
       it 'accepts a block as an alternative' do
-        expect(subject.or { fail }).to be(subject)
+        expect(subject.or { fail }).to be(subject.value)
       end
 
       it 'ignores all values' do
-        expect(subject.or(:foo, :bar, :baz) { fail }).to be(subject)
+        expect(subject.or(:foo, :bar, :baz) { fail }).to be(subject.value)
       end
     end
 


### PR DESCRIPTION
This is little bit strange that `.or` returns proper `value` or `Some(value)` depends on existing