### PR TITLE
Add #value_or for Maybe monad

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -92,6 +92,13 @@ module Dry
           self
         end
 
+        # Returns value. It exists to keep the interface identical to that of {Maybe::None}.
+        #
+        # @return [Object]
+        def value_or(*)
+          value
+        end
+
         # @return [String]
         def to_s
           "Some(#{value.inspect})"
@@ -142,6 +149,13 @@ module Dry
           else
             args[0]
           end
+        end
+
+        # Returns the passed value
+        #
+        # @returns [Object]
+        def value_or(val)
+          val
         end
 
         # @return [String]

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
     end
 
+    describe '#value_or' do
+      it 'returns existing value' do
+        expect(subject.value_or('baz')).to eql(subject.value)
+      end
+    end
+
     describe '#to_maybe' do
       let(:subject) { maybe::Some.new('foo').to_maybe }
 
@@ -183,6 +189,12 @@ RSpec.describe(Dry::Monads::Maybe) do
         end
 
         expect(result).to eql('baz')
+      end
+    end
+
+    describe '#value_or' do
+      it 'returns passed value' do
+        expect(subject.value_or('baz')).to eql('baz')
       end
     end
 


### PR DESCRIPTION
This is the same as `getOrElse` for Scala's `Option`, we decided to segregate this from `or` method.