### PR TITLE
Added `#tee` method to discard a successful result and keep a failure

### DIFF
--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -74,6 +74,19 @@ module Dry
           Right.new(bind(*args, &block))
         end
 
+        # Does the same thing as #bind except it returns the original monad
+        # when the result is a Right.
+        #
+        # @example
+        #   Dry::Monads.Right(4).tee { Right('ok') } # => Right(4)
+        #   Dry::Monads.Right(4).tee { Left('fail') } # => Left('fail')
+        #
+        # @param [Array<Object>] args arguments will be transparently passed through to #bind
+        # @return [Either]
+        def tee(*args, &block)
+          bind(*args, &block).bind { self }
+        end
+
         # Ignores arguments and returns self. It exists to keep the interface
         # identical to that of {Either::Left}.
         #
@@ -118,6 +131,14 @@ module Dry
         #
         # @return [Either::Left]
         def fmap(*)
+          self
+        end
+
+        # Ignores the input parameter and returns self. It exists to keep the interface
+        # identical to that of {Either::Right}.
+        #
+        # @return [Either::Left]
+        def tee(*)
           self
         end
 

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -120,6 +120,17 @@ RSpec.describe(Dry::Monads::Either) do
       it { is_expected.to be_an_instance_of maybe::Some }
       it { is_expected.to eql(maybe::Some.new('foo')) }
     end
+
+    describe '#tee' do
+      it 'passes through itself when the block returns a Right' do
+        expect(subject.tee(->(*) { either::Right.new('ignored') })).to eql(subject)
+      end
+
+      it 'returns the block result when it is a left' do
+        expect(subject.tee(->(*) { either::Left.new('failure') }))
+          .to be_an_instance_of either::Left
+      end
+    end
   end
 
   describe either::Left do
@@ -204,6 +215,20 @@ RSpec.describe(Dry::Monads::Either) do
 
       it { is_expected.to be_an_instance_of maybe::None }
       it { is_expected.to eql(maybe::None.new) }
+    end
+
+    describe '#tee' do
+      it 'accepts a proc and returns itself' do
+        expect(subject.tee(upcase)).to be subject
+      end
+
+      it 'accepts a block and returns itseld' do
+        expect(subject.tee { |s| s.upcase }).to be subject
+      end
+
+      it 'ignores arguments' do
+        expect(subject.tee(1, 2, 3) { fail }).to be subject
+      end
     end
   end
 end


### PR DESCRIPTION
This method allows to chain 'check'-like steps where a successful result is mapped to a pass-through and a failing result is passed to the next step.

```ruby
Dry::Monads.Right(4).tee { Right('ok') } # => Right(4)
Dry::Monads.Right(4).tee { Left('fail') } # => Left('fail')
Dry::Monads.Left('fail').tee { raise } # => Left('fail')
```
