### PR TITLE
Allow passing extra kwargs to Either monad

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,3 +62,6 @@ Lint/HandleExceptions:
 Security/JSONLoad:
   Exclude:
     - 'spec/**/*'
+
+AllCops:
+  TargetRubyVersion: 2.1

--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -115,7 +115,13 @@ module Dry
         #
         # @return [Array]
         def prepare_proc_args(proc, args, kwargs)
-          proc_object = proc.is_a?(Proc) ? proc : proc.method(:call)
+          proc_object =
+            if proc.is_a?(Proc) || proc.is_a?(Method)
+              proc
+            else
+              proc.method(:call)
+            end
+
           proc_parameter_types = proc_object.parameters.flatten
           proc_args = args
 
@@ -127,6 +133,7 @@ module Dry
           end
           proc_args
         end
+
       end
 
       # Represents a value that is in an incorrect state, i.e. something went wrong.

--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -54,9 +54,9 @@ module Dry
         #                             to this object along with the internal value
         # @return [Object] result of calling proc or block on the internal value
         def bind(*args, **kwargs, &block)
-          if block
+          if block_given?
             block_args = prepare_proc_args(block, args, kwargs)
-            block.call(*block_args)
+            yield(*block_args)
           else
             proc = args.shift
             proc_args = prepare_proc_args(proc, args, kwargs)
@@ -115,17 +115,9 @@ module Dry
         #
         # @return [Array]
         def prepare_proc_args(proc, args, kwargs)
-          proc_object =
-            if proc.is_a?(Proc) || proc.is_a?(Method)
-              proc
-            else
-              proc.method(:call)
-            end
-
-          proc_parameter_types = proc_object.parameters.flatten
           proc_args = args
 
-          if proc_parameter_types[0] =~ /key/
+          if proc_parameter_types(proc)[0] =~ /key/
             proc_args << kwargs.merge(value)
           else
             proc_args.unshift(value)
@@ -133,7 +125,16 @@ module Dry
           end
           proc_args
         end
+      end
 
+      def proc_parameter_types(proc)
+        proc_object =
+          if proc.is_a?(Proc) || proc.is_a?(Method)
+            proc
+          else
+            proc.method(:call)
+          end
+        proc_object.parameters.flatten
       end
 
       # Represents a value that is in an incorrect state, i.e. something went wrong.

--- a/spec/integration/either_spec.rb
+++ b/spec/integration/either_spec.rb
@@ -129,11 +129,11 @@ RSpec.describe(Dry::Monads::Either) do
     end
 
     example 'using required keyword arguments' do
-      result = Right(foo: 0, bar: 0, baz: 0).fmap do |foo: , **rest|
-        { foo: 1, **rest }
-      end.fmap do |bar: , **rest|
+      result = Right(foo: 0, bar: 0, baz: 0).fmap do |foo:, **rest|
+        { foo: foo + 1, **rest }
+      end.fmap do |bar:, **rest|
         { bar: bar + 1, **rest }
-      end.fmap do |foo: , bar: , **rest|
+      end.fmap do |foo:, bar:, **rest|
         { **rest, baz: foo + bar }
       end
 

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -45,17 +45,46 @@ RSpec.describe(Dry::Monads::Either) do
         expect(result).to be true
       end
 
-      it 'passes extra arguments to a proc' do
-        proc = lambda do |value, c|
-          expect(value).to eql('foo')
-          expect(c).to eql(:foo)
-          true
+      describe 'passing extra arguments to a proc' do
+        it 'passes only normal extra arguments' do
+          proc = lambda do |value, c1, c2|
+            expect(value).to eql('foo')
+            expect(c1).to eql(:foo)
+            expect(c2).to eql(:bar)
+            true
+          end
+
+          subject.bind(proc, :foo, :bar)
         end
 
-        result = subject.bind(proc, :foo)
+        it 'passes only keyword extra arguments' do
+          initial_monad = either::Right.new(value: 'foo')
 
-        expect(result).to be true
+          proc = lambda do |value:, c1:, c2:|
+            expect(value).to eql('foo')
+            expect(c1).to eql(:foo)
+            expect(c2).to eql(:bar)
+            true
+          end
+
+          initial_monad.bind(proc, c1: :foo, c2: :bar)
+        end
+
+        it 'passes both normal and keyword extra arguments' do
+          
+          proc = lambda do |value1, value2, c1:, c2:|
+            expect(value1).to eql('foo')
+            expect(value2).to eql('bar')
+            expect(c1).to eql(:foo)
+            expect(c2).to eql(:bar)
+            true
+          end
+
+          subject.bind(proc, 'bar', c1: :foo, c2: :bar)
+        end
       end
+
+      
     end
 
     describe '#fmap' do

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe(Dry::Monads::Either) do
         end
 
         it 'passes both normal and keyword extra arguments' do
-          
           proc = lambda do |value1, value2, c1:, c2:|
             expect(value1).to eql('foo')
             expect(value2).to eql('bar')
@@ -83,8 +82,6 @@ RSpec.describe(Dry::Monads::Either) do
           subject.bind(proc, 'bar', c1: :foo, c2: :bar)
         end
       end
-
-      
     end
 
     describe '#fmap' do


### PR DESCRIPTION
As for now, Either monad .bind method supports passing only normal extra agruments or normal with keywords.

Failure example:
proc = lambda {|a:, b:, c:| }
Dry::Monads::Right(a: 1).bind(proc, b: 1, c: 1) - will fail, because internally proc receives arguments as proc.call({a: 1}, {b: 1, c: 1})

This PR, allows passing extra keyword arguments. 
