### PR TITLE
Allow Right(nil) to be transformed to None via #to_maybe

### DIFF
--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -103,7 +103,11 @@ module Dry
 
         # @return [Maybe::Some]
         def to_maybe
-          Maybe::Some.new(value)
+          if value.nil?
+            Kernel.warn('Unexpected coercion: Right(nil) will be coerced into None')
+          end
+
+          Dry::Monads::Maybe(value)
         end
       end
 

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -115,10 +115,24 @@ RSpec.describe(Dry::Monads::Either) do
     end
 
     describe '#to_maybe' do
-      let(:subject) { either::Right.new('foo').to_maybe }
+      context 'when value is nil' do
+        let(:subject) { either::Right.new(nil).to_maybe }
 
-      it { is_expected.to be_an_instance_of maybe::Some }
-      it { is_expected.to eql(maybe::Some.new('foo')) }
+        it { is_expected.to be_an_instance_of maybe::None }
+
+        it 'warns about unexpected transformation' do
+          expect { either::Right.new(nil).to_maybe }.to output(
+            "Unexpected transformation: Right(nil) will transform to None\n"
+          ).to_stderr
+        end
+      end
+
+      context 'when value is not nil' do
+        let(:subject) { either::Right.new('foo').to_maybe }
+
+        it { is_expected.to be_an_instance_of maybe::Some }
+        it { is_expected.to eql(maybe::Some.new('foo')) }
+      end
     end
 
     describe '#tee' do


### PR DESCRIPTION
This makes Either#to_maybe behave more like Haskell's rightToMaybe
function (https://hackage.haskell.org/package/either-4.4.1.1/docs/Data-Either-Combinators.html#v:rightToMaybe)
