### PR TITLE
Add Either#either function

### DIFF
--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -31,6 +31,13 @@ module Dry
           @right = right
         end
 
+        # Apply the second function to value.
+        #
+        # @api public
+        def either(_, f)
+          f.call(value)
+        end
+
         # Returns false
         def left?
           false
@@ -80,6 +87,13 @@ module Dry
         # @param left [Object] a value in an error state
         def initialize(left)
           @left = left
+        end
+
+        # Apply the first function to value.
+        #
+        # @api public
+        def either(f, _)
+          f.call(value)
         end
 
         # Returns true

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe(Dry::Monads::Either) do
       end
     end
 
+    describe '#either' do
+      subject do
+        either::Right.new('Foo').either(
+          lambda { |v| v.downcase },
+          lambda { |v| v.upcase }
+        )
+      end
+
+      it { is_expected.to eq('FOO') }
+    end
+
     describe '#fmap' do
       it 'accepts a proc and lifts the result to either' do
         expect(subject.fmap(upcase)).to eql(upcased_subject)
@@ -218,6 +229,17 @@ RSpec.describe(Dry::Monads::Either) do
       it 'ignores extra arguments' do
         expect(subject.bind(1, 2, 3) { fail }).to be subject
       end
+    end
+
+    describe '#either' do
+      subject do
+        either::Left.new('Foo').either(
+          lambda { |v| v.downcase },
+          lambda { |v| v.upcase }
+        )
+      end
+
+      it { is_expected.to eq('foo') }
     end
 
     describe '#fmap' do


### PR DESCRIPTION
Example of usage:

```ruby
pipeline = [
  Authorize,
  ValidatesRequest,
  Filter,
  Order,
  Paginate
]

def execute_pipeline(pipeline)
  pipeline.reduce(Right(request.raw_post)) do |acc, processor|
    acc.bind(processor)
  end
end

execute_pipeline(pipeline).either(
  lambda { |v| ErrorSerializer.new(v) },
  lambda { |v| ResponseSerializer.new(v) }
)
```

https://hackage.haskell.org/package/base-4.9.0.0/docs/Data-Either.html#v:either