### PR TITLE
Add List monad

### DIFF
--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,6 +1,7 @@
 require 'dry/monads/either'
 require 'dry/monads/maybe'
 require 'dry/monads/try'
+require 'dry/monads/list'
 
 module Dry
   # @api public
@@ -37,6 +38,12 @@ module Dry
     # @return [Either::Left]
     def Left(value)
       Either::Left.new(value)
+    end
+
+    # @param values [Array<Object>] list of values
+    # @return [List]
+    def [](*values)
+      List.new(values)
     end
   end
 end

--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -88,7 +88,7 @@ module Dry
         # @example
         #   Dry::Monads.Right(4).fmap(&:succ).fmap(->(n) { n**2 }) # => Right(25)
         #
-        # @param [Array<Object>] args arguments will be transparently passed through to #bind
+        # @param args [Array<Object>] arguments will be transparently passed through to #bind
         # @return [Either::Right]
         def fmap(*args, &block)
           Right.new(bind(*args, &block))
@@ -145,7 +145,7 @@ module Dry
         # @example
         #   Dry::Monads.Left(ArgumentError.new('error message')).or(&:message) # => "error message"
         #
-        # @param [Array<Object>] args arguments that will be passed to a block
+        # @param args [Array<Object>] arguments that will be passed to a block
         #                             if one was given, otherwise the first
         #                             value will be returned
         # @return [Object]
@@ -163,7 +163,7 @@ module Dry
         #   Dry::Monads.Left.new('no value').or_fmap('value') # => Right("value")
         #   Dry::Monads.Left.new('no value').or_fmap { 'value' } # => Right("value")
         #
-        # @param [Array<Object>] args arguments will be passed to the underlying `#or` call
+        # @param args [Array<Object>] arguments will be passed to the underlying `#or` call
         # @return [Either::Right] Wrapped value
         def or_fmap(*args, &block)
           Right.new(self.or(*args, &block))

--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -1,6 +1,7 @@
 require 'dry/equalizer'
 
 require 'dry/monads/right_biased'
+require 'dry/monads/transformer'
 
 module Dry
   module Monads
@@ -9,6 +10,8 @@ module Dry
     # @api public
     class Either
       include Dry::Equalizer(:right, :left)
+      include Transformer
+
       attr_reader :right, :left
 
       # Turns an enumerable of Either values into a single Either-wrapped

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -93,7 +93,7 @@ module Dry
       # @param [List] other Other list
       # @return [List]
       def +(other)
-        List.new(value + other.value)
+        List.new(to_ary + other.to_ary)
       end
 
       # Returns a string representation of the list.

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -3,10 +3,18 @@ require 'dry/equalizer'
 module Dry
   module Monads
     class List
+      # Builds a list.
+      #
+      # @param [Array<Object>] values List elements
+      # @return [List]
       def self.[](*values)
         new(values)
       end
 
+      # Coerces a value to a list. `nil` will be coerced to an empty list.
+      #
+      # @param [Object] value Value
+      # @return [List]
       def self.coerce(value)
         if value.nil?
           List.new([])
@@ -19,41 +27,80 @@ module Dry
 
       include Dry::Equalizer(:value)
 
+      # Internal array value
       attr_reader :value
 
+      # @api private
       def initialize(value)
         @value = value
       end
 
+      # Lifts a block/proc and runs it against each member of the list.
+      # The block must return a value coercible to a list.
+      # As in other monads if no block given the first argument will
+      # be treated as callable and used instead.
+      #
+      # @example
+      #   Dry::Monads::List[1, 2].bind { |x| [x + 1] } # => List[2, 3]
+      #   Dry::Monads::List[1, 2].bind(-> x { [x, x + 1] }) # => List[1, 2, 2, 3]
+      #
+      # @param [Array<Object>] args arguments will be passed to the block or proc
+      # @return [List]
       def bind(*args)
         if block_given?
           List.coerce(value.map { |v| yield(v, *args) }.reduce(:+))
         else
           obj, *rest = args
-          List.coerce(value.map { |v| obj.call(v, *rest) }.reduce(:+))
+          List.coerce(value.map { |v| obj.(v, *rest) }.reduce(:+))
         end
       end
 
+      # Maps a block over the list. Acts as `Array#map`.
+      # As in other monads if no block given the first argument will
+      # be treated as callable and used instead.
+      #
+      # @example
+      #   Dry::Monads::List[1, 2].fmap { |x| x + 1 } # => List[2, 3]
+      #
+      # @param [Array<Object>] args arguments will be passed to the block or proc
+      # @return [List]
       def fmap(*args)
         if block_given?
           List.new(value.map { |v| yield(v, *args) })
         else
           obj, *rest = args
-          List.new(value.map { |v| obj.call(v, *rest) })
+          List.new(value.map { |v| obj.(v, *rest) })
         end
       end
 
+      # Concatenates two lists.
+      #
+      # @example
+      #   Dry::Monads::List[1, 2] + Dry::Monads::List[3, 4] # => List[1, 2, 3, 4]
+      #
+      # @param [List] other Other list
+      # @return [List]
       def +(other)
         List.new(value + other.value)
       end
 
+      # Returns a string representation of the list.
+      #
+      # @example
+      #   Dry::Monads::List[1, 2, 3].inspect # => "List[1, 2, 3]"
+      #
+      # @return [String]
       def inspect
         "List#{ value.inspect }"
       end
       alias_method :to_s, :inspect
 
+      # Coerces to an array
       alias_method :to_ary, :value
       alias_method :to_a, :to_ary
+
+      # Empty list
+      EMPTY = List.new([].freeze).freeze
 
       module Mixin
         List = List

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -50,6 +50,11 @@ module Dry
         List.new(value + other.value)
       end
 
+      def inspect
+        "List#{ value.inspect }"
+      end
+      alias_method :to_s, :inspect
+
       module Mixin
         List = List
         L = List

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -6,7 +6,7 @@ module Dry
     class List
       # Builds a list.
       #
-      # @param [Array<Object>] values List elements
+      # @param values [Array<Object>] List elements
       # @return [List]
       def self.[](*values)
         new(values)
@@ -45,7 +45,7 @@ module Dry
       #   Dry::Monads::List[1, 2].bind { |x| [x + 1] } # => List[2, 3]
       #   Dry::Monads::List[1, 2].bind(-> x { [x, x + 1] }) # => List[1, 2, 2, 3]
       #
-      # @param [Array<Object>] args arguments will be passed to the block or proc
+      # @param args [Array<Object>] arguments will be passed to the block or proc
       # @return [List]
       def bind(*args)
         if block_given?
@@ -63,7 +63,7 @@ module Dry
       # @example
       #   Dry::Monads::List[1, 2].fmap { |x| x + 1 } # => List[2, 3]
       #
-      # @param [Array<Object>] args arguments will be passed to the block or proc
+      # @param args [Array<Object>] arguments will be passed to the block or proc
       # @return [List]
       def fmap(*args)
         if block_given?
@@ -91,7 +91,7 @@ module Dry
       # @example
       #   Dry::Monads::List[1, 2] + Dry::Monads::List[3, 4] # => List[1, 2, 3, 4]
       #
-      # @param [List] other Other list
+      # @param other [List] Other list
       # @return [List]
       def +(other)
         List.new(to_ary + other.to_ary)
@@ -112,23 +112,23 @@ module Dry
       alias_method :to_ary, :value
       alias_method :to_a, :to_ary
 
-      # Returns first element wrapped with a `Maybe`.
+      # Returns the first element.
       #
-      # @return [Maybe<Object>]
+      # @return [Object]
       def first
-        Maybe.lift(value.first)
+        value.first
       end
 
-      # Returns last element wrapped with a `Maybe`.
+      # Returns the last element.
       #
-      # @return [Maybe<Object>]
+      # @return [Object]
       def last
-        Maybe.lift(value.last)
+        value.last
       end
 
       # Folds the list from the left.
       #
-      # @param [Object] initial Initial value
+      # @param initial [Object] Initial value
       # @return [Object]
       def fold_left(initial)
         value.reduce(initial) { |acc, v| yield(acc, v) }
@@ -138,7 +138,7 @@ module Dry
 
       # Folds the list from the right.
       #
-      # @param [Object] initial Initial value
+      # @param initial [Object] Initial value
       # @return [Object]
       def fold_right(initial)
         value.reverse.reduce(initial) { |a, b| yield(b, a) }
@@ -179,6 +179,20 @@ module Dry
       # @return [List]
       def reverse
         coerce(value.reverse)
+      end
+
+      # Returns the first element wrapped with a `Maybe`.
+      #
+      # @return [Maybe<Object>]
+      def head
+        Maybe.coerce(value.first)
+      end
+
+      # Returns list's tail.
+      #
+      # @return [List]
+      def tail
+        coerce(value.drop(1))
       end
 
       private

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -1,0 +1,63 @@
+require 'dry/equalizer'
+
+module Dry
+  module Monads
+    class List
+      def self.[](*values)
+        new(values)
+      end
+
+      def self.coerce(value)
+        case value
+        when nil
+          List.new([])
+        when List
+          value
+        when Array
+          List.new(value)
+        else
+          raise ArgumentError, "Can't coerce #{value.inspect} to List"
+        end
+      end
+
+      include Dry::Equalizer(:value)
+
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      def bind(*args)
+        if block_given?
+          List.coerce(value.map { |v| yield(v, *args) }.reduce(:+))
+        else
+          obj, *rest = args
+          List.coerce(value.map { |v| obj.call(v, *rest) }.reduce(:+))
+        end
+      end
+
+      def fmap(*args)
+        if block_given?
+          List.new(value.map { |v| yield(v, *args) })
+        else
+          obj, *rest = args
+          List.new(value.map { |v| obj.call(v, *rest) })
+        end
+      end
+
+      def +(other)
+        List.new(value + other.value)
+      end
+
+      module Mixin
+        List = List
+        L = List
+
+        def List(value)
+          List.coerce(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -126,6 +126,25 @@ module Dry
         Maybe.lift(value.last)
       end
 
+      # Folds the list from the left.
+      #
+      # @param [Object] initial Initial value
+      # @return [Object]
+      def fold_left(initial)
+        value.reduce(initial) { |acc, v| yield(acc, v) }
+      end
+      alias_method :foldl, :fold_left
+      alias_method :reduce, :fold_left
+
+      # Folds the list from the right.
+      #
+      # @param [Object] initial Initial value
+      # @return [Object]
+      def fold_right(initial)
+        value.reverse.reduce(initial) { |a, b| yield(b, a) }
+      end
+      alias_method :foldr, :fold_right
+
       # Empty list
       EMPTY = List.new([].freeze).freeze
 

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -55,6 +55,9 @@ module Dry
       end
       alias_method :to_s, :inspect
 
+      alias_method :to_ary, :value
+      alias_method :to_a, :to_ary
+
       module Mixin
         List = List
         L = List

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -145,6 +145,48 @@ module Dry
       end
       alias_method :foldr, :fold_right
 
+      # Whether the list is empty.
+      #
+      # @return [TrueClass, FalseClass]
+      def empty?
+        value.empty?
+      end
+
+      # Sorts the list.
+      #
+      # @return [List]
+      def sort
+        coerce(value.sort)
+      end
+
+      # Filters elements with a block
+      #
+      # @return [List]
+      def filter
+        coerce(value.select { |e| yield(e) })
+      end
+      alias_method :select, :filter
+
+      # List size.
+      #
+      # @return [Integer]
+      def size
+        value.size
+      end
+
+      # Reverses the list.
+      #
+      # @return [List]
+      def reverse
+        coerce(value.reverse)
+      end
+
+      private
+
+      def coerce(other)
+        self.class.coerce(other)
+      end
+
       # Empty list
       EMPTY = List.new([].freeze).freeze
 

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -73,6 +73,18 @@ module Dry
         end
       end
 
+      # Maps a block over the list. Acts as `Array#map`.
+      # Requires a block.
+      #
+      # @return [List]
+      def map(&block)
+        if block
+          fmap(block)
+        else
+          raise ArgumentError, "Missing block"
+        end
+      end
+
       # Concatenates two lists.
       #
       # @example

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -8,13 +8,10 @@ module Dry
       end
 
       def self.coerce(value)
-        case value
-        when nil
+        if value.nil?
           List.new([])
-        when List
-          value
-        when Array
-          List.new(value)
+        elsif value.respond_to?(:to_ary)
+          List.new(value.to_ary)
         else
           raise ArgumentError, "Can't coerce #{value.inspect} to List"
         end

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -1,4 +1,5 @@
 require 'dry/equalizer'
+require 'dry/monads/maybe'
 
 module Dry
   module Monads
@@ -110,6 +111,20 @@ module Dry
       # Coerces to an array
       alias_method :to_ary, :value
       alias_method :to_a, :to_ary
+
+      # Returns first element wrapped with a `Maybe`.
+      #
+      # @return [Maybe<Object>]
+      def first
+        Maybe.lift(value.first)
+      end
+
+      # Returns last element wrapped with a `Maybe`.
+      #
+      # @return [Maybe<Object>]
+      def last
+        Maybe.lift(value.last)
+      end
 
       # Empty list
       EMPTY = List.new([].freeze).freeze

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -1,5 +1,6 @@
 require 'dry/equalizer'
 require 'dry/monads/maybe'
+require 'dry/monads/transformer'
 
 module Dry
   module Monads
@@ -27,6 +28,7 @@ module Dry
       end
 
       include Dry::Equalizer(:value)
+      include Transformer
 
       # Internal array value
       attr_reader :value

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -10,14 +10,25 @@ module Dry
     class Maybe
       include Dry::Equalizer(:value)
 
-      # Lifts the given value into Maybe::None or Maybe::Some monad.
-      #
-      # @param value [Object] the value to be stored in the monad
-      # @return [Maybe::Some, Maybe::None]
-      def self.lift(value)
-        if value.nil?
-          None.instance
-        else
+      class << self
+        # Lifts the given value into Maybe::None or Maybe::Some monad.
+        #
+        # @param value [Object] the value to be stored in the monad
+        # @return [Maybe::Some, Maybe::None]
+        def coerce(value)
+          if value.nil?
+            None.instance
+          else
+            Some.new(value)
+          end
+        end
+        alias_method :lift, :coerce
+
+        # Wraps the given value with `Some`.
+        #
+        # @param value [Object] the value to be stored in the monad
+        # @return [Maybe::Some, Maybe::None]
+        def pure(value)
           Some.new(value)
         end
       end
@@ -59,7 +70,7 @@ module Dry
         # @example
         #   Dry::Monads.Some(4).fmap(&:succ).fmap(->(n) { n**2 }) # => Some(25)
         #
-        # @param [Array<Object>] args arguments will be transparently passed through to #bind
+        # @param args [Array<Object>] arguments will be transparently passed through to #bind
         # @return [Maybe::Some, Maybe::None] Lifted result, i.e. nil will be mapped to None,
         #                                    other values will be wrapped with Some
         def fmap(*args, &block)
@@ -94,7 +105,7 @@ module Dry
         #   Dry::Monads.None.or('no value') # => "no value"
         #   Dry::Monads.None.or { Time.now } # => current time
         #
-        # @param [Array<Object>] args if no block given the first argument will be returned
+        # @param args [Array<Object>] if no block given the first argument will be returned
         #                             otherwise arguments will be transparently passed to the block
         # @return [Object]
         def or(*args)
@@ -112,7 +123,7 @@ module Dry
         #   Dry::Monads.None.or_fmap('no value') # => Some("no value")
         #   Dry::Monads.None.or_fmap { Time.now } # => Some(current time)
         #
-        # @param [Array<Object>] args arguments will be passed to the underlying `#or` call
+        # @param args [Array<Object>] arguments will be passed to the underlying `#or` call
         # @return [Maybe::Some, Maybe::None] Lifted `#or` result, i.e. nil will be mapped to None,
         #                                    other values will be wrapped with Some
         def or_fmap(*args, &block)

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -1,6 +1,7 @@
 require 'dry/equalizer'
 
 require 'dry/monads/right_biased'
+require 'dry/monads/transformer'
 
 module Dry
   module Monads
@@ -9,6 +10,7 @@ module Dry
     # @api public
     class Maybe
       include Dry::Equalizer(:value)
+      include Transformer
 
       class << self
         # Lifts the given value into Maybe::None or Maybe::Some monad.

--- a/lib/dry/monads/transformer.rb
+++ b/lib/dry/monads/transformer.rb
@@ -1,0 +1,42 @@
+module Dry
+  module Monads
+    module Transformer
+      # Lifts a block/proc over the 2-level nested structure.
+      # This is essentially fmap . fmap (. is the function composition
+      # operator from Haskell) or the functor instance for
+      # a two-level monadic structure like List Either.
+      #
+      # @example
+      #   List[Right(1), Left(1)].fmap2 { |x| x + 1 } # => List[Right(2), Left(1)]
+      #   Right(None).fmap2 { |x| x + 1 } # => Right(None)
+      #
+      # @param args [Array<Object>] arguments will be passed to the block or the proc
+      # @return [Object] some monadic value
+      def fmap2(*args)
+        if block_given?
+          fmap { |a| a.fmap { |b| yield(b, *args) } }
+        else
+          func, *rest = args
+          fmap { |a| a.fmap { |b| func.(b, *rest) } }
+        end
+      end
+
+      # Lifts a block/proc over the 3-level nested structure.
+      #
+      # @example
+      #   List[Right(Some(1)), Left(Some(1))].fmap3 { |x| x + 1 } # => List[Right(Some(2)), Left(Some(1))]
+      #   Right(None).fmap3 { |x| x + 1 } # => Right(None)
+      #
+      # @param args [Array<Object>] arguments will be passed to the block or the proc
+      # @return [Object] some monadic value
+      def fmap3(*args)
+        if block_given?
+          fmap { |a| a.fmap { |b| b.fmap { |c| yield(c, *args) } } }
+        else
+          func, *rest = args
+          fmap { |a| a.fmap { |b| b.fmap { |c| func.(c, *rest) } } }
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -68,7 +68,7 @@ module Dry
         #   success.bind(->(n) { n / 2 }) # => 5
         #   success.bind { |n| n / 0 } # => Try::Failure(ZeroDivisionError: divided by 0)
         #
-        # @param [Array<Object>] args arguments that will be passed to a block
+        # @param args [Array<Object>] arguments that will be passed to a block
         #                             if one was given, otherwise the first
         #                             value assumed to be a Proc (callable)
         #                             object and the rest of args will be passed
@@ -89,7 +89,7 @@ module Dry
         #   success.fmap(&:succ).fmap(&:succ).value # => 12
         #   success.fmap(&:succ).fmap { |n| n / 0 }.fmap(&:succ).value # => nil
         #
-        # @param [Array<Object>] args extra arguments for the block, arguments are being processes
+        # @param args [Array<Object>] extra arguments for the block, arguments are being processes
         #                             just as in #bind
         # @return [Try::Success, Try::Failure]
         def fmap(*args, &block)

--- a/spec/integration/list_spec.rb
+++ b/spec/integration/list_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe(Dry::Monads::List) do
+  list = described_class
+
+  context 'mapping a block' do
+    it 'maps a block over list values' do
+      expect(list[1, 2, 3].fmap { |v| v + 1 }).to eql(list[2, 3, 4])
+    end
+  end
+
+  context 'binding a block' do
+    it 'binds a block' do
+      expect(list[1, 2, 3].bind { |v| [v + 1, v + 2] }).to eql(list[2, 3, 3, 4, 4, 5])
+    end
+  end
+end

--- a/spec/integration/transformers_spec.rb
+++ b/spec/integration/transformers_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe(Dry::Monads::Transformer) do
+  list = Dry::Monads::List
+  right = Dry::Monads::Either::Right.method(:new)
+  left = Dry::Monads::Either::Left.method(:new)
+  some = Dry::Monads::Maybe::Some.method(:new)
+  none = Dry::Monads::Maybe::None.new
+
+  context '2-level composition' do
+    context 'List Either String' do
+      subject(:value) { list[right.('success'), left.('failure')] }
+
+      context 'using fmap2' do
+        example 'for lifting the block' do
+          expect(value.fmap2 { |v| v.upcase }).
+            to eql(list[right.('SUCCESS'), left.('failure')])
+        end
+
+        example 'for lifting over the empty list' do
+          expect(list[].fmap2 { fail }).to eql(list[])
+        end
+
+        example 'with a proc' do
+          expect(value.fmap2(-> v { v.upcase })).
+            to eql(list[right.('SUCCESS'), left.('failure')])
+        end
+      end
+    end
+
+    context 'List Maybe Integer' do
+      subject(:value) { list[some.(2), none] }
+
+      example 'using fmap2 for lifting the block' do
+        expect(value.fmap2 { |v| v + 1 }).
+          to eql(list[some.(3), none])
+      end
+    end
+
+    context 'Either Maybe String' do
+      context 'using fmap2' do
+        example 'with Right Some' do
+          expect(right.(some.('result')).fmap2(&:upcase)).
+            to eql(right.(some.('RESULT')))
+        end
+
+        example 'with Left None' do
+          expect(left.(none).fmap2 { fail }).
+            to eql(left.(none))
+        end
+      end
+    end
+
+    context 'Maybe List Integer' do
+      context 'using fmap2' do
+        example 'with Some' do
+          expect(some.(list[1, 2, 3]).fmap2(&:succ)).
+            to eql(some.(list[2, 3, 4]))
+        end
+
+        example 'with None' do
+          expect(none.fmap2 { fail }).
+            to eql(none)
+        end
+      end
+    end
+  end
+
+  context '3-level composition' do
+    context 'list of eithers' do
+      subject(:value) { list[right.(some.('success')),
+                             right.(none),
+                             left.(some.('failure')),
+                             left.(none)] }
+
+      example 'using fmap3 for lifting the block' do
+        expect(value.fmap3 { |v| v.upcase }).
+          to eql(list[right.(some.('SUCCESS')), right.(none),
+                      left.(some.('failure')), left.(none)])
+      end
+    end
+  end
+end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe(Dry::Monads::List) do
   subject { list[1, 2, 3] }
 
   describe '#inspect' do
-    it 'dumps list to string' do
+    it 'dumps list to a string' do
       expect(subject.inspect).to eql('List[1, 2, 3]')
     end
   end
 
   describe '#to_s' do
-    it 'dumps list to string' do
+    it 'dumps list to a string' do
       expect(subject.to_s).to eql('List[1, 2, 3]')
     end
 
@@ -38,20 +38,40 @@ RSpec.describe(Dry::Monads::List) do
   end
 
   describe '#to_a' do
-    it 'coerces list to array' do
+    it 'coerces to an array' do
       expect(subject.to_a).to eql([1, 2, 3])
     end
   end
 
   describe '#to_ary' do
-    it 'coerces list to array' do
+    it 'coerces to an array' do
       expect(subject.to_ary)
     end
 
-    it 'allows to split list' do
+    it 'allows to split a list' do
       a, *b = subject
       expect(a).to eql(1)
       expect(b).to eql([2, 3])
+    end
+  end
+
+  describe '#bind' do
+    it 'binds a block' do
+      expect(subject.bind { |x| [x * 2] }).to eql(list[2, 4, 6])
+    end
+
+    it 'binds a proc' do
+      expect(subject.bind(-> x { [x * 2] })).to eql(list[2, 4, 6])
+    end
+  end
+
+  describe '#fmap' do
+    it 'maps a block' do
+      expect(subject.fmap { |x| x * 2 }).to eql(list[2, 4, 6])
+    end
+
+    it 'maps a proc' do
+      expect(subject.fmap(-> x { x * 2 })).to eql(list[2, 4, 6])
     end
   end
 end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -174,4 +174,44 @@ RSpec.describe(Dry::Monads::List) do
       expect(subject.foldr(0) { |x, y| x - y }).to eql(2)
     end
   end
+
+  describe '#empty?' do
+    it 'returns false for a non-empty list' do
+      expect(subject).not_to be_empty
+    end
+
+    it 'returns true for an empty list' do
+      expect(empty_list).to be_empty # what a surprise
+    end
+  end
+
+  describe '#sort' do
+    it 'sorts a list' do
+      expect(list[3, 2, 1].sort).to eql(subject)
+    end
+  end
+
+  describe '#filter' do
+    it 'filters with a block' do
+      expect(subject.filter(&:odd?)).to eql(list[1, 3])
+    end
+  end
+
+  describe '#select' do
+    it 'is an alias for filter' do
+      expect(subject.select(&:odd?)).to eql(list[1, 3])
+    end
+  end
+
+  describe '#size' do
+    it 'returns list size' do
+      expect(subject.size).to eql(3)
+    end
+  end
+
+  describe '#reverse' do
+    it 'reverses the list' do
+      expect(subject.reverse).to eql(list[3, 2, 1])
+    end
+  end
 end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -3,6 +3,28 @@ RSpec.describe(Dry::Monads::List) do
 
   subject { list[1, 2, 3] }
 
+  describe '.coerce' do
+    let(:array_like) do
+      Object.new.tap do |o|
+        def o.to_ary
+          %w(a b c)
+        end
+      end
+    end
+
+    it 'coerces nil to an empty list' do
+      expect(list.coerce(nil)).to eql(list.new([]))
+    end
+
+    it 'coerces an array' do
+      expect(list.coerce([1, 2])).to eql(list.new([1, 2]))
+    end
+
+    it 'coerces any array-like object' do
+      expect(list.coerce(array_like)).to eql(list.new(%w(a b c)))
+    end
+  end
+
   describe '#inspect' do
     it 'dumps list to a string' do
       expect(subject.inspect).to eql('List[1, 2, 3]')

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe(Dry::Monads::List) do
+  list = described_class
+
+  subject { list[1, 2, 3] }
+
+  describe '#inspect' do
+    it 'dumps list to string' do
+      expect(subject.inspect).to eql('List[1, 2, 3]')
+    end
+  end
+
+  describe '#to_s' do
+    it 'dumps list to string' do
+      expect(subject.to_s).to eql('List[1, 2, 3]')
+    end
+
+    it 'acts as #inspect' do
+      expect(subject.to_s).to eql(subject.inspect)
+    end
+  end
+
+  describe '#==' do
+    it 'compares two lists' do
+      expect(subject).to eq(list[1, 2, 3])
+    end
+  end
+
+  describe '#eql?' do
+    it 'compares two lists with hash equality' do
+      expect(subject).to eql(list[1, 2, 3])
+    end
+  end
+
+  describe '#+' do
+    it 'concatenates two lists' do
+      expect(subject).to eql(list[1, 2] + list[3])
+    end
+  end
+end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe(Dry::Monads::List) do
   list = described_class
   maybe = Dry::Monads::Maybe
+  some = maybe::Some.method(:new)
+  none = maybe::None.new
 
   subject { list[1, 2, 3] }
   let(:empty_list) { list[] }
@@ -114,22 +116,22 @@ RSpec.describe(Dry::Monads::List) do
   end
 
   describe '#first' do
-    it 'returns Some for non-empty list' do
-      expect(subject.first).to eql(maybe::Some.new(1))
+    it 'returns first value for non-empty list' do
+      expect(subject.first).to eql(1)
     end
 
-    it 'returns None for an empty list' do
-      expect(empty_list.first).to eql(maybe::None.new)
+    it 'returns nil for an empty list' do
+      expect(empty_list.first).to be_nil
     end
   end
 
   describe '#last' do
-    it 'returns Some for non-empty list' do
-      expect(subject.last).to eql(maybe::Some.new(3))
+    it 'returns value for non-empty list' do
+      expect(subject.last).to eql(3)
     end
 
-    it 'returns None for an empty list' do
-      expect(empty_list.last).to eql(maybe::None.new)
+    it 'returns nil for an empty list' do
+      expect(empty_list.last).to be_nil
     end
   end
 
@@ -212,6 +214,30 @@ RSpec.describe(Dry::Monads::List) do
   describe '#reverse' do
     it 'reverses the list' do
       expect(subject.reverse).to eql(list[3, 2, 1])
+    end
+  end
+
+  describe '#head' do
+    it 'returns the first element' do
+      expect(subject.head).to eql(some[1])
+    end
+
+    it 'returns None for an empty list' do
+      expect(empty_list.head).to eql(none)
+    end
+  end
+
+  describe '#tail' do
+    it 'drop the first element' do
+      expect(subject.tail).to eql(list[2, 3])
+    end
+
+    it 'returns an empty list for a list with one item' do
+      expect(list[1].tail).to eql(empty_list)
+    end
+
+    it 'returns an empty list for an empty_list' do
+      expect(empty_list.tail).to eql(empty_list)
     end
   end
 end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe(Dry::Monads::List) do
     it 'concatenates two lists' do
       expect(subject).to eql(list[1, 2] + list[3])
     end
+
+    it 'coerces an argument' do
+      expect(subject + [4, 5]).to eql(list[1, 2, 3, 4, 5])
+    end
   end
 
   describe '#to_a' do

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe(Dry::Monads::List) do
   list = described_class
+  maybe = Dry::Monads::Maybe
 
   subject { list[1, 2, 3] }
+  let(:empty_list) { list[] }
 
   describe '.coerce' do
     let(:array_like) do
@@ -108,6 +110,26 @@ RSpec.describe(Dry::Monads::List) do
 
     it 'requires a block' do
       expect { subject.map }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#first' do
+    it 'returns Some for non-empty list' do
+      expect(subject.first).to eql(maybe::Some.new(1))
+    end
+
+    it 'returns None for an empty list' do
+      expect(empty_list.first).to eql(maybe::None.new)
+    end
+  end
+
+  describe '#last' do
+    it 'returns Some for non-empty list' do
+      expect(subject.last).to eql(maybe::Some.new(3))
+    end
+
+    it 'returns None for an empty list' do
+      expect(empty_list.last).to eql(maybe::None.new)
     end
   end
 end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -36,4 +36,22 @@ RSpec.describe(Dry::Monads::List) do
       expect(subject).to eql(list[1, 2] + list[3])
     end
   end
+
+  describe '#to_a' do
+    it 'coerces list to array' do
+      expect(subject.to_a).to eql([1, 2, 3])
+    end
+  end
+
+  describe '#to_ary' do
+    it 'coerces list to array' do
+      expect(subject.to_ary)
+    end
+
+    it 'allows to split list' do
+      a, *b = subject
+      expect(a).to eql(1)
+      expect(b).to eql([2, 3])
+    end
+  end
 end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -96,4 +96,14 @@ RSpec.describe(Dry::Monads::List) do
       expect(subject.fmap(-> x { x * 2 })).to eql(list[2, 4, 6])
     end
   end
+
+  describe '#map' do
+    it 'maps a block over a list' do
+      expect(subject.map { |x| x * 2 }).to eql(list[2, 4, 6])
+    end
+
+    it 'requires a block' do
+      expect { subject.map }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -132,4 +132,46 @@ RSpec.describe(Dry::Monads::List) do
       expect(empty_list.last).to eql(maybe::None.new)
     end
   end
+
+  describe '#fold_left' do
+    it 'returns initial value for the empty list' do
+      expect(empty_list.fold_left(100) { fail }).to eql(100)
+    end
+
+    it 'folds from the left' do
+      expect(subject.fold_left(0) { |x, y| x - y }).to eql(-6)
+    end
+  end
+
+  describe '#foldl' do
+    it 'is an ailas for fold_left' do
+      expect(subject.foldl(0) { |x, y| x - y }).to eql(-6)
+    end
+  end
+
+  describe '#reduce' do
+    it 'is an ailas for fold_left' do
+      expect(subject.reduce(0) { |x, y| x - y }).to eql(-6)
+    end
+
+    it 'acts as Array#reduce' do
+      expect(subject.reduce(0) { |x, y| x - y }).to eql([1, 2, 3].reduce(0) { |x, y| x - y })
+    end
+  end
+
+  describe '#fold_right' do
+    it 'returns initial value for the empty list' do
+      expect(empty_list.fold_right(100) { fail }).to eql(100)
+    end
+
+    it 'folds from the right' do
+      expect(subject.fold_right(0) { |x, y| x - y }).to eql(2)
+    end
+  end
+
+  describe '#foldr' do
+    it 'is an ailas for fold_right' do
+      expect(subject.foldr(0) { |x, y| x - y }).to eql(2)
+    end
+  end
 end


### PR DESCRIPTION
This adds the `List` monad. This will be a nice addition to `Either` and `Maybe` for things like lists of operations.

This is a WIP, I'm going to add more stuff related to integration with other types of monads.

/cc @solnic @timriley 