### PR TITLE
Add interface of applicative functor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ script:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
   - ruby-head
 env:
   global:

--- a/dry-monads.gemspec
+++ b/dry-monads.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.2.0"
   spec.add_dependency 'dry-equalizer'
   spec.add_dependency 'dry-core'
 

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -89,15 +89,17 @@ module Dry
         # @example happy path
         #   create_user = Dry::Monads::Right(CreateUser.new)
         #   name = Right("John")
-        #   create_user.ap(name) # equivalent to CreateUser.new.call("John")
+        #   create_user.apply(name) # equivalent to CreateUser.new.call("John")
         #
         # @example unhappy path
         #   name = Left(:name_missing)
-        #   create_user.ap(name) # => Left(:name_missing)
+        #   create_user.apply(name) # => Left(:name_missing)
         #
         # @return [RightBiased::Left,RightBiased::Right]
-        def ap(val)
-          raise TypeError, "Cannot call #{ value.inspect }" unless value.respond_to?(:call)
+        def apply(val)
+          unless value.respond_to?(:call)
+            raise TypeError, "Cannot apply #{ val.inspect } to #{ value.inspect }"
+          end
           val.fmap { |unwrapped| curry.(unwrapped) }
         end
 
@@ -190,7 +192,7 @@ module Dry
         # identical to that of {RightBiased::Right}.
         #
         # @return [RightBiased::Left]
-        def ap(*)
+        def apply(*)
           self
         end
       end

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -83,11 +83,27 @@ module Dry
           value
         end
 
+        def ap(val)
+          raise ArgumentError, "Cannot call #{ value.inspect }" unless value.respond_to?(:call)
+          val.fmap { |unwrapped| curry.(unwrapped) }
+        end
+
         private
 
         # @api private
         def destructure(*args, **kwargs)
           [args, kwargs]
+        end
+
+        def curry
+          call = value.method(:call)
+          seq_args = call.parameters.count { |type, _| type == :req }
+
+          if seq_args > 1
+            call.curry
+          else
+            value
+          end
         end
       end
 
@@ -150,6 +166,10 @@ module Dry
           else
             val
           end
+        end
+
+        def ap(*)
+          self
         end
       end
     end

--- a/spec/integration/maybe_spec.rb
+++ b/spec/integration/maybe_spec.rb
@@ -114,9 +114,9 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
 
       it 'works' do
-        expect(Some(build_name.new).ap(Some('John')).ap(Some('Doe'))).to eql(Some('John Doe'))
-        expect(Some(build_name.new).ap(None()).ap(Some('Doe'))).to eql(None())
-        expect(Some(build_name.new).ap(Some('John')).ap(None())).to eql(None())
+        expect(Some(build_name.new).apply(Some('John')).apply(Some('Doe'))).to eql(Some('John Doe'))
+        expect(Some(build_name.new).apply(None()).apply(Some('Doe'))).to eql(None())
+        expect(Some(build_name.new).apply(Some('John')).apply(None())).to eql(None())
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe(Dry::Monads::Maybe) do
       let(:build_name) { -> (first_name:, last_name:) { "#{ first_name } #{ last_name }" } }
 
       it 'works' do
-        expect(Some(build_name).ap(Some(first_name: 'John', last_name: 'Doe'))).to eql(Some('John Doe'))
+        expect(Some(build_name).apply(Some(first_name: 'John', last_name: 'Doe'))).to eql(Some('John Doe'))
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe(Dry::Monads::Maybe) do
       let(:build_name) { -> (first_name, last_name:) { "#{ first_name } #{ last_name }" } }
 
       it 'works' do
-        expect(Some(build_name).ap(Some('John')).ap(Some(last_name: 'Doe'))).to eql(Some('John Doe'))
+        expect(Some(build_name).apply(Some('John')).apply(Some(last_name: 'Doe'))).to eql(Some('John Doe'))
       end
     end
 
@@ -140,13 +140,13 @@ RSpec.describe(Dry::Monads::Maybe) do
       let(:build_name) { -> (first_name, last_name = 'Doe') { "#{ first_name } #{ last_name }" } }
 
       it 'works' do
-        expect(Some(build_name).ap(Some('John'))).to eql(Some('John Doe'))
+        expect(Some(build_name).apply(Some('John'))).to eql(Some('John Doe'))
       end
 
       it 'raises an error on calling .ap on applied value' do
         expect {
-          Some(build_name).ap(Some('John')).ap(Some('Doe'))
-        }.to raise_error(TypeError)
+          Some(build_name).apply(Some('John')).apply(Some('Doe'))
+        }.to raise_error(TypeError, /Cannot apply/)
       end
     end
   end

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -237,8 +237,8 @@ RSpec.describe(Dry::Monads::Either) do
       subject { right[:upcase.to_proc] }
 
       it 'applies a wrapped function' do
-        expect(subject.ap(right['foo'])).to eql(right['FOO'])
-        expect(subject.ap(left['foo'])).to eql(left['foo'])
+        expect(subject.apply(right['foo'])).to eql(right['FOO'])
+        expect(subject.apply(left['foo'])).to eql(left['foo'])
       end
     end
   end
@@ -391,8 +391,8 @@ RSpec.describe(Dry::Monads::Either) do
 
     describe '#ap' do
       it 'does nothing' do
-        expect(subject.ap(right['foo'])).to be(subject)
-        expect(subject.ap(left['foo'])).to be(subject)
+        expect(subject.apply(right['foo'])).to be(subject)
+        expect(subject.apply(left['foo'])).to be(subject)
       end
     end
   end

--- a/spec/unit/either_spec.rb
+++ b/spec/unit/either_spec.rb
@@ -232,6 +232,15 @@ RSpec.describe(Dry::Monads::Either) do
         expect(subject.flip).to eql(left['foo'])
       end
     end
+
+    describe '#ap' do
+      subject { right[:upcase.to_proc] }
+
+      it 'applies a wrapped function' do
+        expect(subject.ap(right['foo'])).to eql(right['FOO'])
+        expect(subject.ap(left['foo'])).to eql(left['foo'])
+      end
+    end
   end
 
   describe either::Left do
@@ -377,6 +386,13 @@ RSpec.describe(Dry::Monads::Either) do
 
       it 'executes a block' do
         expect(subject.value_or { |bar| 'foo' + bar }).to eql('foobar')
+      end
+    end
+
+    describe '#ap' do
+      it 'does nothing' do
+        expect(subject.ap(right['foo'])).to be(subject)
+        expect(subject.ap(left['foo'])).to be(subject)
       end
     end
   end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -163,6 +163,15 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(subject).not_to be_failure
       end
     end
+
+    describe '#ap' do
+      subject { some[:upcase.to_proc] }
+
+      it 'applies a wrapped function' do
+        expect(subject.ap(some['foo'])).to eql(some['FOO'])
+        expect(subject.ap(none)).to eql(none)
+      end
+    end
   end
 
   describe maybe::None do
@@ -301,6 +310,13 @@ RSpec.describe(Dry::Monads::Maybe) do
       it 'returns false' do
         expect(subject).to be_none
         expect(subject).to be_failure
+      end
+    end
+
+    describe '#ap' do
+      it 'does nothing' do
+        expect(subject.ap(some['foo'])).to be(subject)
+        expect(subject.ap(none)).to be(subject)
       end
     end
   end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -168,8 +168,8 @@ RSpec.describe(Dry::Monads::Maybe) do
       subject { some[:upcase.to_proc] }
 
       it 'applies a wrapped function' do
-        expect(subject.ap(some['foo'])).to eql(some['FOO'])
-        expect(subject.ap(none)).to eql(none)
+        expect(subject.apply(some['foo'])).to eql(some['FOO'])
+        expect(subject.apply(none)).to eql(none)
       end
     end
   end
@@ -315,8 +315,8 @@ RSpec.describe(Dry::Monads::Maybe) do
 
     describe '#ap' do
       it 'does nothing' do
-        expect(subject.ap(some['foo'])).to be(subject)
-        expect(subject.ap(none)).to be(subject)
+        expect(subject.apply(some['foo'])).to be(subject)
+        expect(subject.apply(none)).to be(subject)
       end
     end
   end

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -151,8 +151,8 @@ RSpec.describe(Dry::Monads::Try) do
       subject { div_success[:upcase.to_proc] }
 
       it 'applies a wrapped function' do
-        expect(subject.ap(div_success['foo'])).to eql(div_success['FOO'])
-        expect(subject.ap(upcase_failure)).to eql(upcase_failure)
+        expect(subject.apply(div_success['foo'])).to eql(div_success['FOO'])
+        expect(subject.apply(upcase_failure)).to eql(upcase_failure)
       end
     end
   end
@@ -242,8 +242,8 @@ RSpec.describe(Dry::Monads::Try) do
 
     describe '#ap' do
       it 'does nothing' do
-        expect(subject.ap(success[[ZeroDivisionError], 'foo'])).to be(subject)
-        expect(subject.ap(failure[division_error])).to be(subject)
+        expect(subject.apply(success[[ZeroDivisionError], 'foo'])).to be(subject)
+        expect(subject.apply(failure[division_error])).to be(subject)
       end
     end
   end

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe(Dry::Monads::Try) do
   either = Dry::Monads::Either
   maybe = Dry::Monads::Maybe
   some = maybe::Some.method(:new)
+  success = try::Success.method(:new)
+  div_success = -> value { success[[ZeroDivisionError], value] }
+  failure = try::Failure.method(:new)
 
   division_error = 1 / 0 rescue $ERROR_INFO
   no_method_error = no_method rescue $ERROR_INFO
@@ -13,16 +16,16 @@ RSpec.describe(Dry::Monads::Try) do
   let(:divide_by_zero) { ->(_value) { raise division_error } }
 
   describe(try::Success) do
-    subject { described_class.new([ZeroDivisionError], 'foo') }
+    subject { div_success['foo'] }
 
-    let(:upcase_success) { described_class.new([ZeroDivisionError], 'FOO') }
+    let(:upcase_success) { div_success['FOO'] }
     let(:upcase_failure) { try::Failure.new(division_error) }
 
     it { is_expected.to be_success }
     it { is_expected.not_to be_failure }
 
     it { is_expected.to eql(described_class.new([ZeroDivisionError], 'foo')) }
-    it { is_expected.not_to eql(try::Failure.new(division_error)) }
+    it { is_expected.not_to eql(failure[division_error]) }
 
     it 'dumps to string' do
       expect(subject.to_s).to eql('Try::Success("foo")')
@@ -114,11 +117,11 @@ RSpec.describe(Dry::Monads::Try) do
 
     describe '#to_maybe' do
       it 'transforms self to Some if value is not nil' do
-        expect(subject.to_maybe).to eql(maybe::Some.new('foo'))
+        expect(subject.to_maybe).to eql(some['foo'])
       end
 
       it 'returns None if value is nil' do
-        expect(described_class.new([ZeroDivisionError], nil).to_maybe).to eql(maybe::None.new)
+        expect(div_success[nil].to_maybe).to eql(maybe::None.new)
       end
     end
 
@@ -141,6 +144,15 @@ RSpec.describe(Dry::Monads::Try) do
     describe '#or' do
       it 'returns itself' do
         expect(subject.or { fail }).to be(subject)
+      end
+    end
+
+    describe '#ap' do
+      subject { div_success[:upcase.to_proc] }
+
+      it 'applies a wrapped function' do
+        expect(subject.ap(div_success['foo'])).to eql(div_success['FOO'])
+        expect(subject.ap(upcase_failure)).to eql(upcase_failure)
       end
     end
   end
@@ -225,6 +237,13 @@ RSpec.describe(Dry::Monads::Try) do
     describe '#or' do
       it 'returns yields a block' do
         expect(subject.or { some[1] }).to eql(some[1])
+      end
+    end
+
+    describe '#ap' do
+      it 'does nothing' do
+        expect(subject.ap(success[[ZeroDivisionError], 'foo'])).to be(subject)
+        expect(subject.ap(failure[division_error])).to be(subject)
       end
     end
   end


### PR DESCRIPTION
fixes #32 
This allows applying wrapped callables, the thing called "[Applicative functor](https://en.wikipedia.org/wiki/Applicative_functor)". From time to time it makes code simpler

```ruby
create_user = Right(CreateUser.new)
values = Schema.(params).to_either
create_user.apply(values) # => Left(validation errors) or Right(<#User>)
```

Note that `CreateUser#call` in this case is supposed to return a user struct free of the Either wrapper, otherwise, we would get a double-wrapped value as a result (i.e. `Right(Right(<#User>))`). We could have another method in `Either` this, e.g. `apply_bind`.

/cc @v-shmyhlo it only took me a few months :)