### PR TITLE
Implement the case equality operator for right-biased monads

### DIFF
--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -24,7 +24,7 @@ module Dry
     end
 
     # Creates a module that has two methods: `Success` and `Failure`.
-    # `Success` is identical to {Monads#Success} and Failure
+    # `Success` is identical to {Result::Mixin::Constructors#Success} and Failure
     # rejects values that don't conform the value of the `error`
     # parameter. This is essentially a Result type with the `Failure` part
     # fixed.

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -15,6 +15,11 @@ module Dry
       Result::Mixin::Constructors
     ].freeze
 
+    Some = Maybe::Some
+    None = Maybe::None
+    Success = Result::Success
+    Failure = Result::Failure
+
     extend(*CONSTRUCTORS)
 
     def self.included(base)

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -8,54 +8,19 @@ require 'dry/monads/result/fixed'
 module Dry
   # @api public
   module Monads
-    extend self
-
     Undefined = Dry::Core::Constants::Undefined
 
-    # Stores the given value in one of the subtypes of {Maybe} monad.
-    # It is essentially a wrapper for {Maybe.lift}.
-    #
-    # @param value [Object] the value to be stored in the monad
-    # @return [Maybe::Some, Maybe::None]
-    def Maybe(value)
-      Maybe.lift(value)
-    end
+    CONSTRUCTORS = [
+      Maybe::Mixin::Constructors,
+      Result::Mixin::Constructors
+    ].freeze
 
-    # @param value [Object] the value to be stored in the monad
-    # @return [Maybe::Some]
-    def Some(value)
-      Maybe::Some.new(value)
-    end
+    extend(*CONSTRUCTORS)
 
-    # @return [Maybe::None]
-    def None
-      Maybe::Some::None.instance
-    end
+    def self.included(base)
+      super
 
-    # @note This method is provided for backwards compatibility.
-    # @param value [Object] the value to be stored in the monad
-    # @return [Result::Success]
-    def Right(value)
-      Result::Success.new(value)
-    end
-
-    # @note This method is provided for backwards compatibility.
-    # @param value [Object] the value to be stored in the monad
-    # @return [Result::Failure]
-    def Left(value)
-      Result::Failure.new(value)
-    end
-
-    # @param value [Object] the value to be stored in the monad
-    # @return [Result::Success]
-    def Success(value)
-      Result::Success.new(value)
-    end
-
-    # @param value [Object] the value to be stored in the monad
-    # @return [Result::Failure]
-    def Failure(value)
-      Result::Failure.new(value)
+      base.include(*CONSTRUCTORS)
     end
 
     # Creates a module that has two methods: `Success` and `Failure`.
@@ -89,7 +54,7 @@ module Dry
     #
     # @param error [#===] the type of allowed failures
     # @return [Module]
-    def Result(error, **options)
+    def self.Result(error, **options)
       Result::Fixed[error, **options]
     end
   end

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,3 +1,4 @@
+require 'dry/core/constants'
 require 'dry/monads/maybe'
 require 'dry/monads/try'
 require 'dry/monads/list'
@@ -8,6 +9,8 @@ module Dry
   # @api public
   module Monads
     extend self
+
+    Undefined = Dry::Core::Constants::Undefined
 
     # Stores the given value in one of the subtypes of {Maybe} monad.
     # It is essentially a wrapper for {Maybe.lift}.

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -163,27 +163,31 @@ module Dry
         Some = Some
         None = None
 
-        # @param value [Object] the value to be stored in the monad
-        # @return [Maybe::Some, Maybe::None]
-        def Maybe(value)
-          Maybe.lift(value)
-        end
+        module Constructors
+          # @param value [Object] the value to be stored in the monad
+          # @return [Maybe::Some, Maybe::None]
+          def Maybe(value)
+            Maybe.lift(value)
+          end
 
-        # @param value [Object] the value to be stored in the monad
-        # @return [Maybe::Some]
-        def Some(value = Dry::Core::Constants::Undefined, &block)
-          if value.equal?(Dry::Core::Constants::Undefined)
-            raise ArgumentError, "No value given" if block.nil?
-            Some.new(block)
-          else
-            Some.new(value)
+          # @param value [Object] the value to be stored in the monad
+          # @return [Maybe::Some]
+          def Some(value = Dry::Core::Constants::Undefined, &block)
+            if value.equal?(Dry::Core::Constants::Undefined)
+              raise ArgumentError, 'No value given' if block.nil?
+              Some.new(block)
+            else
+              Some.new(value)
+            end
+          end
+
+          # @return [Maybe::None]
+          def None
+            None.instance
           end
         end
 
-        # @return [Maybe::None]
-        def None
-          None.instance
-        end
+        include Constructors
       end
     end
   end

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -1,5 +1,6 @@
 require 'dry/equalizer'
 require 'dry/core/deprecations'
+require 'dry/core/constants'
 
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
@@ -170,8 +171,13 @@ module Dry
 
         # @param value [Object] the value to be stored in the monad
         # @return [Maybe::Some]
-        def Some(value)
-          Some.new(value)
+        def Some(value = Dry::Core::Constants::Undefined, &block)
+          if value.equal?(Dry::Core::Constants::Undefined)
+            raise ArgumentError, "No value given" if block.nil?
+            Some.new(block)
+          else
+            Some.new(value)
+          end
         end
 
         # @return [Maybe::None]

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -1,4 +1,5 @@
 require 'dry/equalizer'
+require 'dry/core/constants'
 
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
@@ -198,6 +199,10 @@ module Dry
             val
           end
         end
+
+        def ===(other)
+          Failure === other && failure === other.failure
+        end
       end
 
       # A module that can be included for easier access to Result monads.
@@ -207,15 +212,25 @@ module Dry
 
         # @param value [Object] the value to be stored in the monad
         # @return [Result::Success]
-        def Success(value)
-          Success.new(value)
+        def Success(value = Dry::Core::Constants::Undefined, &block)
+          if value.equal?(Dry::Core::Constants::Undefined)
+            raise ArgumentError, "No value given" if block.nil?
+            Success.new(block)
+          else
+            Success.new(value)
+          end
         end
         alias_method :Right, :Success
 
         # @param value [Object] the value to be stored in the monad
         # @return [Result::Failure]
-        def Failure(value)
-          Failure.new(value)
+        def Failure(value = Dry::Core::Constants::Undefined, &block)
+          if value.equal?(Dry::Core::Constants::Undefined)
+            raise ArgumentError, "No value given" if block.nil?
+            Failure.new(block)
+          else
+            Failure.new(value)
+          end
         end
         alias_method :Left, :Failure
       end

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -3,6 +3,7 @@ require 'dry/core/constants'
 
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
+require 'dry/monads/maybe'
 
 module Dry
   module Monads
@@ -210,29 +211,33 @@ module Dry
         Success = Dry::Monads::Result::Success
         Failure = Dry::Monads::Result::Failure
 
-        # @param value [Object] the value to be stored in the monad
-        # @return [Result::Success]
-        def Success(value = Dry::Core::Constants::Undefined, &block)
-          if value.equal?(Dry::Core::Constants::Undefined)
-            raise ArgumentError, "No value given" if block.nil?
-            Success.new(block)
-          else
-            Success.new(value)
+        module Constructors
+          # @param value [Object] the value to be stored in the monad
+          # @return [Result::Success]
+          def Success(value = Dry::Core::Constants::Undefined, &block)
+            if value.equal?(Dry::Core::Constants::Undefined)
+              raise ArgumentError, 'No value given' if block.nil?
+              Success.new(block)
+            else
+              Success.new(value)
+            end
           end
-        end
-        alias_method :Right, :Success
+          alias_method :Right, :Success
 
-        # @param value [Object] the value to be stored in the monad
-        # @return [Result::Failure]
-        def Failure(value = Dry::Core::Constants::Undefined, &block)
-          if value.equal?(Dry::Core::Constants::Undefined)
-            raise ArgumentError, "No value given" if block.nil?
-            Failure.new(block)
-          else
-            Failure.new(value)
+          # @param value [Object] the value to be stored in the monad
+          # @return [Result::Failure]
+          def Failure(value = Dry::Core::Constants::Undefined, &block)
+            if value.equal?(Dry::Core::Constants::Undefined)
+              raise ArgumentError, 'No value given' if block.nil?
+              Failure.new(block)
+            else
+              Failure.new(value)
+            end
           end
+          alias_method :Left, :Failure
         end
-        alias_method :Left, :Failure
+
+        include Constructors
       end
     end
 

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -201,6 +201,8 @@ module Dry
           end
         end
 
+        # @param other [Result]
+        # @return [Boolean]
         def ===(other)
           Failure === other && failure === other.failure
         end

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -116,6 +116,8 @@ module Dry
           val.fmap { |unwrapped| curry.(unwrapped) }
         end
 
+        # @param other [RightBiased]
+        # @return [Boolean]
         def ===(other)
           self.class == other.class && value! === other.value!
         end

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -116,6 +116,10 @@ module Dry
           val.fmap { |unwrapped| curry.(unwrapped) }
         end
 
+        def ===(other)
+          self.class == other.class && value! === other.value!
+        end
+
         private
 
         # @api private

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -162,6 +162,8 @@ module Dry
           end
         end
 
+        # @param other [Try]
+        # @return [Boolean]
         def ===(other)
           Error === other && exception === other.exception
         end

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -1,6 +1,8 @@
 require 'dry/equalizer'
 
 require 'dry/monads/right_biased'
+require 'dry/monads/result'
+require 'dry/monads/maybe'
 
 module Dry
   module Monads
@@ -198,7 +200,7 @@ module Dry
 
         def Value(value = Undefined, exceptions = DEFAULT_EXCEPTIONS, &block)
           if value.equal?(Undefined)
-            raise ArgumentError, "No value given" if block.nil?
+            raise ArgumentError, 'No value given' if block.nil?
             Try::Value.new(exceptions, block)
           else
             Try::Value.new(exceptions, value)
@@ -207,7 +209,7 @@ module Dry
 
         def Error(error = Undefined, &block)
           if error.equal?(Undefined)
-            raise ArgumentError, "No value given" if block.nil?
+            raise ArgumentError, 'No value given' if block.nil?
             Try::Error.new(block)
           else
             Try::Error.new(error)

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -159,6 +159,10 @@ module Dry
             args[0]
           end
         end
+
+        def ===(other)
+          Error === other && exception === other.exception
+        end
       end
 
       # A module that can be included for easier access to Try monads.
@@ -190,6 +194,24 @@ module Dry
         def Try(*exceptions, &f)
           catchable = exceptions.empty? ? DEFAULT_EXCEPTIONS : exceptions.flatten
           Try.lift(catchable, f)
+        end
+
+        def Value(value = Undefined, exceptions = DEFAULT_EXCEPTIONS, &block)
+          if value.equal?(Undefined)
+            raise ArgumentError, "No value given" if block.nil?
+            Try::Value.new(exceptions, block)
+          else
+            Try::Value.new(exceptions, value)
+          end
+        end
+
+        def Error(error = Undefined, &block)
+          if error.equal?(Undefined)
+            raise ArgumentError, "No value given" if block.nil?
+            Try::Error.new(block)
+          else
+            Try::Error.new(error)
+          end
         end
       end
     end

--- a/spec/integration/maybe_spec.rb
+++ b/spec/integration/maybe_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe(Dry::Monads::Maybe) do
     end
   end
 
-  context 'matching' do
+  describe 'matching' do
     let(:match) do
       -> value do
         case value

--- a/spec/integration/monads_spec.rb
+++ b/spec/integration/monads_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe(Dry::Monads) do
 
   describe 'maybe monad' do
     describe '.Maybe' do
-      describe 'lifting to Some' do
+      describe 'mapping to Some' do
         subject { m.Some(5) }
 
         it { is_expected.to eq maybe::Some.new(5) }
       end
 
-      describe 'lifting to None' do
+      describe 'mapping to None' do
         subject { m.Maybe(nil) }
 
         it { is_expected.to eq maybe::None.new }
@@ -20,12 +20,25 @@ RSpec.describe(Dry::Monads) do
     end
 
     describe '.Some' do
-      subject { m.Some(10) }
+      context 'with a value' do
+        subject { m.Some(10) }
 
-      it { is_expected.to eq maybe::Some.new(10) }
+        it { is_expected.to eq maybe::Some.new(10) }
 
-      example 'lifting nil produces an error' do
-        expect { m.Some(nil) }.to raise_error(ArgumentError)
+        example 'mapping nil produces an error' do
+          expect { m.Some(nil) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'lifting a block' do
+        let(:block) { -> _ { Integer } }
+        subject { m.Some(&block) }
+
+        it { is_expected.to eql(maybe::Some.new(block)) }
+      end
+
+      example 'using without values produces an error' do
+        expect { m.Some() }.to raise_error(ArgumentError, 'No value given')
       end
     end
 
@@ -56,18 +69,17 @@ RSpec.describe(Dry::Monads) do
     end
   end
 
-   describe 'result monad' do
+  describe 'result monad' do
     describe '.Success' do
       subject { m.Success('everything went right') }
 
-      it { is_expected.to eq result::Success.new('everything went right') }
+      it { is_expected.to eql(result::Success.new('everything went right')) }
     end
 
     describe '.Failure' do
       subject { m.Failure('something has gone wrong') }
 
-      it { is_expected.to eq result::Failure.new('something has gone wrong') }
+      it { is_expected.to eql(result::Failure.new('something has gone wrong')) }
     end
   end
-
 end

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe(Dry::Monads::Result) do
-  result = described_class
-
   include Dry::Monads::Result::Mixin
 
   describe 'matching' do

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe(Dry::Monads::Result) do
   include Dry::Monads::Result::Mixin
 
   describe 'matching' do
+    include Dry::Monads::Maybe::Mixin
+
     let(:match) do
       -> value do
         case value
@@ -34,6 +36,11 @@ RSpec.describe(Dry::Monads::Result) do
       expect(match.(Failure('foo'))).to eql(:failure_rg)
       expect(match.(Failure(100))).to eql(:failure_block)
       expect(match.(Success(-1))).to eql(:else)
+    end
+
+    it 'works with nested values' do
+      expect(Success(Some(Integer))).to be === Success(Some(5))
+      expect(Success(Some(Integer))).not_to be === Success(None())
     end
   end
 end

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe(Dry::Monads::Result) do
+  result = described_class
+
+  include Dry::Monads::Result::Mixin
+
+  describe 'matching' do
+    let(:match) do
+      -> value do
+        case value
+        when Success('foo') then :foo_eql
+        when Success(/\w+/) then :bar_rg
+        when Success(42) then :int_match
+        when Success(10..50) then :int_range
+        when Success(-> x { x > 9000 }) then :int_proc_arg
+        when Success { |x| x > 100 } then :int_proc_block
+        when Failure(10) then :ten_eql
+        when Failure(/\w+/) then :failure_rg
+        when Failure { |x| x > 90 } then :failure_block
+        else
+          :else
+        end
+      end
+    end
+
+    it 'can be used in a case statement' do
+      expect(match.(Success('foo'))).to eql(:foo_eql)
+      expect(match.(Success('bar'))).to eql(:bar_rg)
+      expect(match.(Success(42))).to eql(:int_match)
+      expect(match.(Success(42.0))).to eql(:int_match)
+      expect(match.(Success(12))).to eql(:int_range)
+      expect(match.(Success(9123))).to eql(:int_proc_arg)
+      expect(match.(Success(144))).to eql(:int_proc_block)
+      expect(match.(Failure(10))).to eql(:ten_eql)
+      expect(match.(Failure('foo'))).to eql(:failure_rg)
+      expect(match.(Failure(100))).to eql(:failure_block)
+      expect(match.(Success(-1))).to eql(:else)
+    end
+  end
+end

--- a/spec/integration/try_spec.rb
+++ b/spec/integration/try_spec.rb
@@ -128,4 +128,38 @@ RSpec.describe(Dry::Monads::Try) do
       end
     end
   end
+
+  describe 'matching' do
+    let(:match) do
+      -> value do
+        case value
+        when Value('foo') then :foo_eql
+        when Value(/\w+/) then :bar_rg
+        when Value(42) then :int_match
+        when Value(10..50) then :int_range
+        when Value(-> x { x > 9000 }) then :int_proc_arg
+        when Value { |x| x > 100 } then :int_proc_block
+        when Error(10) then :ten_eql
+        when Error(/\w+/) then :failure_rg
+        when Error { |x| x > 90 } then :failure_block
+        else
+          :else
+        end
+      end
+    end
+
+    it 'can be used in a case statement' do
+      expect(match.(Value('foo'))).to eql(:foo_eql)
+      expect(match.(Value('bar'))).to eql(:bar_rg)
+      expect(match.(Value(42))).to eql(:int_match)
+      expect(match.(Value(42.0))).to eql(:int_match)
+      expect(match.(Value(12))).to eql(:int_range)
+      expect(match.(Value(9123))).to eql(:int_proc_arg)
+      expect(match.(Value(144))).to eql(:int_proc_block)
+      expect(match.(Error(10))).to eql(:ten_eql)
+      expect(match.(Error('foo'))).to eql(:failure_rg)
+      expect(match.(Error(100))).to eql(:failure_block)
+      expect(match.(Value(-1))).to eql(:else)
+    end
+  end
 end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -351,4 +351,29 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
     end
   end
+
+  describe maybe::Mixin do
+    subject(:obj) { Object.new.tap { |o| o.extend(maybe::Mixin) } }
+
+    describe '#Some' do
+      example 'with plain value' do
+        expect(subject.Some('thing')).to eql(some['thing'])
+      end
+
+      example 'with a block' do
+        block = -> { 'thing' }
+        expect(subject.Some(&block)).to eql(some[block])
+      end
+
+      it 'raises an ArgumentError on missing value' do
+        expect { subject.Some() }.to raise_error(ArgumentError, 'No value given')
+      end
+    end
+
+    describe '#None' do
+      example 'returns the singleton' do
+        expect(subject.None()).to be(maybe::None.instance)
+      end
+    end
+  end
 end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -178,6 +178,15 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(subject.apply(none)).to eql(none)
       end
     end
+
+    describe '#===' do
+      it 'matches on the wrapped value' do
+        expect(some['foo']).to be === some['foo']
+        expect(some[/\w+/]).to be === some['foo']
+        expect(some[:bar]).not_to be === some['foo']
+        expect(some[10..50]).to be === some[42]
+      end
+    end
   end
 
   describe maybe::None do
@@ -329,6 +338,16 @@ RSpec.describe(Dry::Monads::Maybe) do
       it 'does nothing' do
         expect(subject.apply(some['foo'])).to be(subject)
         expect(subject.apply(none)).to be(subject)
+      end
+    end
+
+    describe '#===' do
+      it 'matches against other None' do
+        expect(none).to be === maybe::None.new
+      end
+
+      it "doesn't match a Some" do
+        expect(none).not_to be === some['foo']
       end
     end
   end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe(Dry::Monads::Result) do
-  mresult = described_class
+  result = described_class
   maybe = Dry::Monads::Maybe
   some = maybe::Some.method(:new)
-  failure = mresult::Failure.method(:new)
-  success = mresult::Success.method(:new)
+  failure = result::Failure.method(:new)
+  success = result::Success.method(:new)
 
   let(:upcase) { :upcase.to_proc }
 
-  describe mresult::Success do
+  describe result::Success do
     subject { success['foo'] }
 
     let(:upcased_subject) { success['FOO'] }
@@ -37,13 +37,13 @@ RSpec.describe(Dry::Monads::Result) do
       end
 
       it 'passes extra arguments to a block' do
-        result = subject.bind(:foo) do |value, c|
+        expr_result = subject.bind(:foo) do |value, c|
           expect(value).to eql('foo')
           expect(c).to eql(:foo)
           true
         end
 
-        expect(result).to be true
+        expect(expr_result).to be true
       end
 
       it 'passes extra arguments to a proc' do
@@ -53,15 +53,15 @@ RSpec.describe(Dry::Monads::Result) do
           true
         end
 
-        result = subject.bind(proc, :foo)
+        expr_result = subject.bind(proc, :foo)
 
-        expect(result).to be true
+        expect(expr_result).to be true
       end
     end
 
     describe '#result' do
       subject do
-        mresult::Success.new('Foo').result(
+        result::Success.new('Foo').result(
           lambda { |v| v.downcase },
           lambda { |v| v.upcase }
         )
@@ -80,14 +80,14 @@ RSpec.describe(Dry::Monads::Result) do
       end
 
       it 'passes extra arguments to a block' do
-        result = subject.fmap(:foo, :bar) do |value, c1, c2|
+        expr_result = subject.fmap(:foo, :bar) do |value, c1, c2|
           expect(value).to eql('foo')
           expect(c1).to eql(:foo)
           expect(c2).to eql(:bar)
           true
         end
 
-        expect(result).to eql(mresult::Success.new(true))
+        expect(expr_result).to eql(result::Success.new(true))
       end
 
       it 'passes extra arguments to a proc' do
@@ -98,9 +98,9 @@ RSpec.describe(Dry::Monads::Result) do
           true
         end
 
-        result = subject.fmap(proc, :foo, :bar)
+        expr_result = subject.fmap(proc, :foo, :bar)
 
-        expect(result).to eql(mresult::Success.new(true))
+        expect(expr_result).to eql(result::Success.new(true))
       end
     end
 
@@ -133,22 +133,22 @@ RSpec.describe(Dry::Monads::Result) do
     end
 
     describe '#to_result' do
-      subject { mresult::Success.new('foo').to_result }
+      subject { result::Success.new('foo').to_result }
 
       it 'returns self' do
-        is_expected.to eql(mresult::Success.new('foo'))
+        is_expected.to eql(result::Success.new('foo'))
       end
     end
 
     describe '#to_maybe' do
-      subject { mresult::Success.new('foo').to_maybe }
+      subject { result::Success.new('foo').to_maybe }
 
       it { is_expected.to be_an_instance_of maybe::Some }
       it { is_expected.to eql(some['foo']) }
 
       context 'value is nil' do
         around { |ex| suppress_warnings { ex.run } }
-        subject { mresult::Success.new(nil).to_maybe }
+        subject { result::Success.new(nil).to_maybe }
 
         it { is_expected.to be_an_instance_of maybe::None }
         it { is_expected.to eql(maybe::None.new) }
@@ -157,12 +157,12 @@ RSpec.describe(Dry::Monads::Result) do
 
     describe '#tee' do
       it 'passes through itself when the block returns a Success' do
-        expect(subject.tee(->(*) { mresult::Success.new('ignored') })).to eql(subject)
+        expect(subject.tee(->(*) { result::Success.new('ignored') })).to eql(subject)
       end
 
       it 'returns the block result when it is a Failure' do
-        expect(subject.tee(->(*) { mresult::Failure.new('failure') }))
-          .to be_an_instance_of mresult::Failure
+        expect(subject.tee(->(*) { result::Failure.new('failure') }))
+          .to be_an_instance_of result::Failure
       end
     end
 
@@ -177,18 +177,18 @@ RSpec.describe(Dry::Monads::Result) do
     end
 
     context 'keyword values' do
-      subject { mresult::Success.new(foo: 'foo') }
+      subject { result::Success.new(foo: 'foo') }
       let(:struct) { Class.new(Hash)[bar: 'foo'] }
 
       describe '#bind' do
         it 'passed extra keywords to block along with value' do
-          result = subject.bind(bar: 'bar') do |foo:, bar: |
+          expr_result = subject.bind(bar: 'bar') do |foo:, bar: |
             expect(foo).to eql('foo')
             expect(bar).to eql('bar')
             true
           end
 
-          expect(result).to be true
+          expect(expr_result).to be true
         end
 
         it "doesn't use destructuring if it's not needed" do
@@ -199,28 +199,28 @@ RSpec.describe(Dry::Monads::Result) do
     end
 
     context 'mixed values' do
-      subject { mresult::Success.new(foo: 'foo', 'bar' => 'bar') }
+      subject { result::Success.new(foo: 'foo', 'bar' => 'bar') }
 
       describe '#bind' do
         it 'passed extra keywords to block along with value' do
-          result = subject.bind(:baz, quux: 'quux') do |value, baz, quux: |
+          expr_result = subject.bind(:baz, quux: 'quux') do |value, baz, quux: |
             expect(value).to eql(subject.value!)
             expect(baz).to eql(:baz)
             expect(quux).to eql('quux')
             true
           end
 
-          expect(result).to be true
+          expect(expr_result).to be true
         end
 
         example 'keywords from value takes precedence' do
-          result = subject.bind(foo: 'bar', bar: 'bar') do |foo:, bar: |
+          expr_result = subject.bind(foo: 'bar', bar: 'bar') do |foo:, bar: |
             expect(foo).to eql('foo')
             expect(bar).to eql('bar')
             true
           end
 
-          expect(result).to be true
+          expect(expr_result).to be true
         end
       end
     end
@@ -256,15 +256,15 @@ RSpec.describe(Dry::Monads::Result) do
     end
   end
 
-  describe mresult::Failure do
-    subject { mresult::Failure.new('bar') }
+  describe result::Failure do
+    subject { result::Failure.new('bar') }
 
     it { is_expected.not_to be_success }
 
     it { is_expected.to be_failure }
 
     it { is_expected.to eql(described_class.new('bar')) }
-    it { is_expected.not_to eql(mresult::Success.new('bar')) }
+    it { is_expected.not_to eql(result::Success.new('bar')) }
 
     it 'dumps to string' do
       expect(subject.to_s).to eql('Failure("bar")')
@@ -290,7 +290,7 @@ RSpec.describe(Dry::Monads::Result) do
 
     describe '#result' do
       subject do
-        mresult::Failure.new('Foo').result(
+        result::Failure.new('Foo').result(
           lambda { |v| v.downcase },
           lambda { |v| v.upcase }
         )
@@ -323,14 +323,14 @@ RSpec.describe(Dry::Monads::Result) do
       end
 
       it 'passes extra arguments to a block' do
-        result = subject.or(:foo, :bar) do |value, c1, c2|
+        expr_result = subject.or(:foo, :bar) do |value, c1, c2|
           expect(value).to eql('bar')
           expect(c1).to eql(:foo)
           expect(c2).to eql(:bar)
           'baz'
         end
 
-        expect(result).to eql('baz')
+        expect(expr_result).to eql('baz')
       end
     end
 
@@ -344,27 +344,27 @@ RSpec.describe(Dry::Monads::Result) do
       end
 
       it 'passes extra arguments to a block' do
-        result = subject.or_fmap(:foo, :bar) do |value, c1, c2|
+        expr_result = subject.or_fmap(:foo, :bar) do |value, c1, c2|
           expect(value).to eql('bar')
           expect(c1).to eql(:foo)
           expect(c2).to eql(:bar)
           'baz'
         end
 
-        expect(result).to eql(success['baz'])
+        expect(expr_result).to eql(success['baz'])
       end
     end
 
     describe '#to_result' do
-      let(:subject) { mresult::Failure.new('bar').to_result }
+      let(:subject) { result::Failure.new('bar').to_result }
 
       it 'returns self' do
-        is_expected.to eql(mresult::Failure.new('bar'))
+        is_expected.to eql(result::Failure.new('bar'))
       end
     end
 
     describe '#to_maybe' do
-      let(:subject) { mresult::Failure.new('bar').to_maybe }
+      let(:subject) { result::Failure.new('bar').to_maybe }
 
       it { is_expected.to be_an_instance_of maybe::None }
       it { is_expected.to eql(maybe::None.new) }
@@ -419,6 +419,40 @@ RSpec.describe(Dry::Monads::Result) do
         expect(failure[/\w+/]).to be === subject
         expect(failure[String]).to be === subject
         expect(failure['foo']).not_to be === subject
+      end
+    end
+  end
+
+  describe result::Mixin do
+    subject(:obj) { Object.new.tap { |o| o.extend(result::Mixin) } }
+
+    describe '#Success' do
+      example 'with plain value' do
+        expect(subject.Success('something')).to eql(success['something'])
+      end
+
+      example 'with a block' do
+        block = -> { 'something' }
+        expect(subject.Success(&block)).to eql(success[block])
+      end
+
+      it 'raises an ArgumentError on missing value' do
+        expect { subject.Success() }.to raise_error(ArgumentError, 'No value given')
+      end
+    end
+
+    describe '#Failure' do
+      example 'with plain value' do
+        expect(subject.Failure('something else')).to eql(failure['something else'])
+      end
+
+      example 'with a block' do
+        block = -> { 'something' }
+        expect(subject.Failure(&block)).to eql(failure[block])
+      end
+
+      it 'raises an ArgumentError on missing value' do
+        expect { subject.Failure() }.to raise_error(ArgumentError, 'No value given')
       end
     end
   end

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -159,6 +159,14 @@ RSpec.describe(Dry::Monads::Try) do
         expect(subject.apply(upcase_error)).to eql(upcase_error)
       end
     end
+
+    describe '#===' do
+      it 'matches on the wrapped value' do
+        expect(div_value[10]).to be === div_value[10]
+        expect(div_value[Integer]).to be === div_value[10]
+        expect(div_value[String]).not_to be === div_value[10]
+      end
+    end
   end
 
   describe(try::Error) do
@@ -250,6 +258,13 @@ RSpec.describe(Dry::Monads::Try) do
       it 'does nothing' do
         expect(subject.apply(value[[ZeroDivisionError], 'foo'])).to be(subject)
         expect(subject.apply(error[division_error])).to be(subject)
+      end
+    end
+
+    describe '#===' do
+      it 'matches using the error value' do
+        expect(error[division_error]).to be === error[division_error]
+        expect(error[ZeroDivisionError]).to be === error[division_error]
       end
     end
   end

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -268,4 +268,38 @@ RSpec.describe(Dry::Monads::Try) do
       end
     end
   end
+
+  describe try::Mixin do
+    subject(:obj) { Object.new.tap { |o| o.extend(try::Mixin) } }
+
+    describe '#Value' do
+      example 'with plain value' do
+        expect(subject.Value('something')).to eql(value[[StandardError], 'something'])
+      end
+
+      example 'with a block' do
+        block = -> { 'something' }
+        expect(subject.Value(&block)).to eql(value[[StandardError], block])
+      end
+
+      it 'raises an ArgumentError on missing value' do
+        expect { subject.Value() }.to raise_error(ArgumentError, 'No value given')
+      end
+    end
+
+    describe '#Error' do
+      example 'with plain value' do
+        expect(subject.Error(division_error)).to eql(error[division_error])
+      end
+
+      example 'with a block' do
+        block = -> { 'something' }
+        expect(subject.Error(&block)).to eql(error[block])
+      end
+
+      it 'raises an ArgumentError on missing value' do
+        expect { subject.Error() }.to raise_error(ArgumentError, 'No value given')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows basic case matching on monadic values:

```ruby
case value
when Some(1), Some(2) then :one_or_two
when Some(3..5) then :three_to_five
else
  :something_else
end
```

```ruby
case value
when Success then [:ok, value.value!]
when Failure(TimeoutError) then [:timeout]
when Failure(ConnectionClosed) then [:net_error]
when Failure then [:generic_error]
else
  raise "Unhandled case"
end
```

Nested structures are supported:

```ruby
case value
when Success(None()) then :nothing
when Success(Some { |x| x > 10 }) then :something
when Success(Some) then :something_else
when Failure then :error
end
```

The reason behind this is mostly why not, the only sad fact is `case` in Ruby does not require exhaustiveness when no `else` is provided.