### PR TITLE
Add emulation of Haskell's do notation

### DIFF
--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -4,6 +4,7 @@ require 'dry/monads/try'
 require 'dry/monads/list'
 require 'dry/monads/result'
 require 'dry/monads/result/fixed'
+require 'dry/monads/do'
 
 module Dry
   # @api public

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -11,17 +11,75 @@ module Dry
         end
       end
 
-      def self.for(method)
+      # Generates a module that passes a block to methods
+      # that either unwraps a single-valued monadic value or halts
+      # the execution.
+      #
+      # @example A complete example
+      #
+      #   class CreateUser
+      #     include Dry::Monads::Result::Mixin
+      #     include Dry::Monads::Try::Mixin
+      #     include Dry::Monads::Do.for(:call)
+      #
+      #     attr_reader :user_repo
+      #
+      #     def initialize(:user_repo)
+      #       @user_repo = user_repo
+      #     end
+      #
+      #     def call(params)
+      #       json = yield parse_json(params)
+      #       hash = yield validate(json)
+      #
+      #       user_repo.transaction do
+      #         user = yield create_user(hash[:user])
+      #         yield create_profile(user, hash[:profile])
+      #       end
+      #
+      #       Success(user)
+      #     end
+      #
+      #     private
+      #
+      #     def parse_json(params)
+      #       Try(JSON::ParserError) {
+      #         JSON.parse(params)
+      #       }.to_result
+      #     end
+      #
+      #     def validate(json)
+      #       UserSchema.(json).to_monad
+      #     end
+      #
+      #     def create_user(user_data)
+      #       Try(Sequel::Error) {
+      #         user_repo.create(user_data)
+      #       }.to_result
+      #     end
+      #
+      #     def create_profile(user, profile_data)
+      #       Try(Sequel::Error) {
+      #         user_repo.create_profile(user, profile_data)
+      #       }.to_result
+      #     end
+      #   end
+      #
+      # @param [Array<Symbol>] methods
+      # @return [Module]
+      def self.for(*methods)
         mod = Module.new do
-          define_method(method) do |*args|
-            begin
-              super(*args) do |*ms|
-                unwrapped = ms.map { |m| m.or { halt(m) }.value! }
-                ms.size == 1 ? unwrapped[0] : unwrapped
+          methods.each do |method|
+            class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+              def #{ method }(*)
+                super do |*ms|
+                  unwrapped = ms.map { |m| m.or { halt(m) }.value! }
+                  ms.size == 1 ? unwrapped[0] : unwrapped
+                end
+              rescue Halt => e
+                e.result
               end
-            rescue Halt => e
-              e.result
-            end
+            RUBY
           end
         end
 

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -1,0 +1,22 @@
+module Dry
+  module Monads
+    module Do
+      def self.for(method)
+        mod = Module.new do
+          define_method(method) do |*args|
+            super(*args) do |*ms|
+              unwrapped = ms.map { |m| m.or { return m }.value! }
+              ms.size == 1 ? unwrapped[0] : unwrapped
+            end
+          end
+        end
+
+        Module.new do
+          singleton_class.send(:define_method, :included) do |base|
+            base.prepend(mod)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -1,12 +1,26 @@
 module Dry
   module Monads
     module Do
+      class Halt < StandardError
+        attr_reader :result
+
+        def initialize(result)
+          super()
+
+          @result = result
+        end
+      end
+
       def self.for(method)
         mod = Module.new do
           define_method(method) do |*args|
-            super(*args) do |*ms|
-              unwrapped = ms.map { |m| m.or { return m }.value! }
-              ms.size == 1 ? unwrapped[0] : unwrapped
+            begin
+              super(*args) do |*ms|
+                unwrapped = ms.map { |m| m.or { halt(m) }.value! }
+                ms.size == 1 ? unwrapped[0] : unwrapped
+              end
+            rescue Halt => e
+              e.result
             end
           end
         end
@@ -14,6 +28,10 @@ module Dry
         Module.new do
           singleton_class.send(:define_method, :included) do |base|
             base.prepend(mod)
+          end
+
+          def halt(result)
+            raise Halt.new(result)
           end
         end
       end

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe(Dry::Monads::Do) do
             m1 = Some(1)
             m2 = Some(2)
 
-            Some(yield(m1, m2).sum)
+            Some(yield(m1, m2).reduce(:+))
           end
         end
       end
@@ -135,7 +135,7 @@ RSpec.describe(Dry::Monads::Do) do
             m1 = None()
             m2 = Some(2)
 
-            Some(yield(m1, m2).sum)
+            Some(yield(m1, m2).reduce(:+))
           end
         end
       end
@@ -152,7 +152,7 @@ RSpec.describe(Dry::Monads::Do) do
             m1 = Some(1)
             m2 = None()
 
-            Some(yield(m1, m2).sum)
+            Some(yield(m1, m2).reduce(:+))
           end
         end
       end
@@ -171,7 +171,7 @@ RSpec.describe(Dry::Monads::Do) do
             m1 = Try { 1 }
             m2 = Try { 2 }
 
-            Dry::Monads::Try::pure(yield(m1, m2).sum)
+            Dry::Monads::Try::pure(yield(m1, m2).reduce(:+))
           end
         end
       end
@@ -188,7 +188,7 @@ RSpec.describe(Dry::Monads::Do) do
             m1 = Try { 1 / 0 }
             m2 = Try { 2 }
 
-            Dry::Monads::Try::pure(yield(m1, m2).sum)
+            Dry::Monads::Try::pure(yield(m1, m2).reduce(:+))
           end
         end
       end
@@ -205,7 +205,7 @@ RSpec.describe(Dry::Monads::Do) do
             m1 = Try { 1 }
             m2 = Try { 2 / 0 }
 
-            Dry::Monads::Try::pure(yield(m1, m2).sum)
+            Dry::Monads::Try::pure(yield(m1, m2).reduce(:+))
           end
         end
       end

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe(Dry::Monads::Do) do
+  include Dry::Monads
+
+  let(:klass) do
+    spec = self
+
+    Class.new do
+      include Dry::Monads::Do.for(:call)
+      include Dry::Monads
+    end
+  end
+
+  let(:instance) { klass.new }
+
+  context 'with Result' do
+    context 'successful case' do
+      before do
+        klass.class_eval do
+          def call
+            m1 = Success(1)
+            m2 = Success(2)
+
+            one = yield m1
+            two = yield m2
+
+            Success(one + two)
+          end
+        end
+      end
+
+      it 'returns result of a statement' do
+        expect(instance.call).to eql(Success(3))
+      end
+    end
+
+    context 'first failure' do
+      before do
+        klass.class_eval do
+          def call
+            m1 = Failure(:no_one)
+            m2 = Success(2)
+
+            one = yield m1
+            two = yield m2
+
+            Success(one + two)
+          end
+        end
+      end
+
+      it 'returns failure' do
+        expect(instance.call).to eql(Failure(:no_one))
+      end
+    end
+
+    context 'second failure' do
+      before do
+        klass.class_eval do
+          def call
+            m1 = Success(1)
+            m2 = Failure(:no_two)
+
+            one = yield m1
+            two = yield m2
+
+            Success(one + two)
+          end
+        end
+      end
+
+      it 'returns failure' do
+        expect(instance.call).to eql(Failure(:no_two))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby doesn't have for/list comprehensions hence we cannot emulate the do notation in full but still, it's possible to get rid of a lot of glue code.

This PR adds support for things like this:

```ruby
class MyShinyOperation
  include Dry::Monads::Result::Mixin
  include Dry::Monads::Try::Mixin
  include Dry::Monads::Do.for(:call)

  def call(params)
    json = yield parse(params)
    data = yield validate(json)
    result = yield run_logic(data)

    Success(result)
  end

  def parse(params)
    Try(JSON::ParserError) { JSON.parse(params) }
  end

  def validate(json)
    Schema.(json).to_monad
  end

  def run_logic(data)
    if ....
      Success(result: something_persisted)
    else
      Failure(:failed_for_some_reason)
    end
  end
end
```

Instead of
```ruby
  def call(params)
    parse(params).bind { |json| validate(json) }.bind { |data| run_logic(data).bind { |result| Success(result) } }
  end
```
we now have
```ruby
  def call(params)
    json = yield parse(params)
    data = yield validate(json)
    result = yield run_logic(data)

    Success(result)
  end
```

I know it's arguable which one is better but `Do` allows you to work with not related monadic values, consider this

```ruby
  def call(data)
    user = yield fetch_user(data)
    profile = yield fetch_profile(data)

    updated_user = yield update_user(user, data)    
    updated_profile = yield update_profile(profile, data)

    Success(updated_user, updated_profile)
  end
```

IMO, this is better than

```ruby
  def call(data)
    fetch_user(data).bind do |user|
      fetch_profile(data).bind do |profile|
        update_user(user, data).bind do |updated_user|
          update_profile(profile, data).bind do |updated_profile|
            Success(updated_user, updated_profile)
          end
        end
      end
    end
  end
```