### PR TITLE
Add support for arrays and lists to Do

### DIFF
--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -29,7 +29,13 @@ module Dry
           if value.nil?
             List.new([], type)
           elsif value.respond_to?(:to_ary)
-            List.new(value.to_ary, type)
+            values = value.to_ary
+
+            if !values.empty? && type.nil? && values[0].respond_to?(:monad)
+              List.new(values, values[0].monad)
+            else
+              List.new(values, type)
+            end
           else
             raise TypeError, "Can't coerce #{value.inspect} to List"
           end

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -304,10 +304,10 @@ RSpec.describe(Dry::Monads::List) do
 
       it 'flips a list' do
         expect(subject.traverse { |x| list[x] }).
-          to eql(list[list[1, 2]])
+          to eql(list[list[1, 2]].typed(list))
 
         expect(subject.traverse { |x| list[x, x + 1] }).
-          to eql(list[list[1, 2], list[1, 3], list[2, 2], list[2, 3]])
+          to eql(list[list[1, 2], list[1, 3], list[2, 2], list[2, 3]].typed(list))
       end
     end
 


### PR DESCRIPTION
```ruby
class Operation
  include Dry::Monads
  include Dry::Monads::Task::Mixin
  include Dry::Monads::Do.for(:call)

  def call
    result = yield [
      Task[:io] { get_name },
      Task[:io] { get_age }
    ]
  
    Success(result)
  end

  def get_name
    'Jane'
  end

  def get_age
    20
  end
end

Operation.new.call # => Success(List["Jane", 20])
```