### PR TITLE
Store caller location in None/Failure

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -107,6 +107,12 @@ module Dry
         @instance = new.freeze
         singleton_class.send(:attr_reader, :instance)
 
+        attr_reader :trace
+
+        def initialize(trace = RightBiased::Left.trace_caller)
+          @trace = trace
+        end
+
         # If a block is given passes internal value to it and returns the result,
         # otherwise simply returns the parameter val.
         #
@@ -189,7 +195,7 @@ module Dry
 
           # @return [Maybe::None]
           def None
-            None.instance
+            None.new(RightBiased::Left.trace_caller)
           end
         end
 

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -107,6 +107,10 @@ module Dry
         @instance = new.freeze
         singleton_class.send(:attr_reader, :instance)
 
+        # Line where the value was constructed
+        #
+        # @return [String]
+        # @api public
         attr_reader :trace
 
         def initialize(trace = RightBiased::Left.trace_caller)

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -117,16 +117,24 @@ module Dry
         include RightBiased::Left
         include Dry::Equalizer(:failure)
 
+        # Line where the value was constructed
+        #
+        # @return [String]
+        # @api public
+        attr_reader :trace
+
+        # @param value [Object] failure value
+        # @param trace [String] caller line
+        def initialize(value, trace = RightBiased::Left.trace_caller)
+          @value = value
+          @trace = trace
+        end
+
         # @private
         def failure
           @value
         end
         alias_method :left, :failure
-
-        # @param value [Object] a value in an error state
-        def initialize(value)
-          @value = value
-        end
 
         # Apply the first function to value.
         #
@@ -240,9 +248,9 @@ module Dry
           def Failure(value = Dry::Core::Constants::Undefined, &block)
             if value.equal?(Dry::Core::Constants::Undefined)
               raise ArgumentError, 'No value given' if block.nil?
-              Failure.new(block)
+              Failure.new(block, RightBiased::Left.trace_caller)
             else
-              Failure.new(value)
+              Failure.new(value, RightBiased::Left.trace_caller)
             end
           end
         end

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -106,7 +106,7 @@ module Dry
         #
         # @return [Result::Failure]
         def flip
-          Failure.new(@value)
+          Failure.new(@value, RightBiased::Left.trace_caller)
         end
       end
 
@@ -193,7 +193,7 @@ module Dry
 
         # @return [Maybe::None]
         def to_maybe
-          Maybe::None.instance
+          Maybe::None.new(trace)
         end
 
         # Transform to a Success instance

--- a/lib/dry/monads/result/fixed.rb
+++ b/lib/dry/monads/result/fixed.rb
@@ -11,7 +11,7 @@ module Dry::Monads
         @mod = Module.new do
           define_method(:Failure) do |value|
             if error === value
-              Failure.new(value)
+              Failure.new(value, RightBiased::Left.trace_caller)
             else
               raise InvalidFailureTypeError.new(value)
             end

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -149,6 +149,12 @@ module Dry
 
         deprecate :value, message: '.value is deprecated, use .value! instead'
 
+        # @private
+        # @return [String] Caller location
+        def self.trace_caller
+          caller_locations(2, 2)[0].to_s
+        end
+
         # Raises an error on accessing internal value
         def value!
           raise UnwrapError.new(self)

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -111,7 +111,7 @@ module Dry
         if promise.wait.fulfilled?
           Result::Success.new(promise.value)
         else
-          Result::Failure.new(promise.reason)
+          Result::Failure.new(promise.reason, RightBiased::Left.trace_caller)
         end
       end
 
@@ -119,7 +119,11 @@ module Dry
       #
       # @return [Maybe]
       def to_maybe
-        Maybe.coerce(promise.wait.value)
+        if promise.wait.fulfilled?
+          Maybe::Some.new(promise.value)
+        else
+          Maybe::None.new(RightBiased::Left.trace_caller)
+        end
       end
 
       # @return [String]

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -120,7 +120,7 @@ module Dry
 
         # @return [Result::Success]
         def to_result
-          Dry::Monads::Success(@value)
+          Dry::Monads::Result::Success.new(@value)
         end
 
         # @return [String]
@@ -144,12 +144,12 @@ module Dry
 
         # @return [Maybe::None]
         def to_maybe
-          Dry::Monads::None()
+          Maybe::None.new(RightBiased::Left.trace_caller)
         end
 
         # @return [Result::Failure]
         def to_result
-          Dry::Monads::Failure(exception)
+          Result::Failure.new(exception, RightBiased::Left.trace_caller)
         end
 
         # @return [String]

--- a/spec/integration/maybe_spec.rb
+++ b/spec/integration/maybe_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe(Dry::Monads::Maybe) do
 
       it { is_expected.to eql(maybe::None.new) }
 
-      it 'returns the same object every time' do
-        expect(none).to be None()
+      it 'returns a new instance' do
+        expect(none).to eql(None())
+        expect(none.trace).to include("spec/integration/maybe_spec.rb:7:in `block")
       end
     end
 

--- a/spec/integration/result_fixed_spec.rb
+++ b/spec/integration/result_fixed_spec.rb
@@ -56,6 +56,11 @@ RSpec.describe(Dry::Monads::Result) do
       expect(subject.Failure(:no_user)).to eql(failure.(:no_user))
     end
 
+    it 'tracks the caller' do
+      error = subject.Failure(:no_user)
+      expect(error.trace).to include("spec/integration/result_fixed_spec.rb")
+    end
+
     it 'raises an error on invalid type' do
       expect { subject.Failure("no_user") }.
         to raise_error(

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -206,6 +206,12 @@ RSpec.describe(Dry::Monads::Maybe) do
       expect(subject.inspect).to eql('None')
     end
 
+    describe '#initialize' do
+      it 'traces the caller' do
+        expect(subject.trace).to include("spec/unit/maybe_spec.rb")
+      end
+    end
+
     describe '#value', :suppress_deprecations do
       it 'returns wrapped value' do
         expect(subject.value).to be nil
@@ -371,8 +377,8 @@ RSpec.describe(Dry::Monads::Maybe) do
     end
 
     describe '#None' do
-      example 'returns the singleton' do
-        expect(subject.None()).to be(maybe::None.instance)
+      example 'tracks the caller' do
+        expect(subject.None().trace).to include("spec/unit/maybe_spec.rb")
       end
     end
   end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -229,6 +229,10 @@ RSpec.describe(Dry::Monads::Result) do
       it 'transforms Success to Failure' do
         expect(subject.flip).to eql(failure['foo'])
       end
+
+      it 'tracks the caller' do
+        expect(subject.flip.trace).to include("spec/unit/result_spec.rb")
+      end
     end
 
     describe '#apply' do
@@ -368,6 +372,10 @@ RSpec.describe(Dry::Monads::Result) do
 
       it { is_expected.to be_an_instance_of maybe::None }
       it { is_expected.to eql(maybe::None.new) }
+
+      it 'tracks the caller' do
+        expect(subject.to_maybe.trace).to include("spec/unit/result_spec.rb")
+      end
     end
 
     describe '#tee' do
@@ -424,7 +432,7 @@ RSpec.describe(Dry::Monads::Result) do
   end
 
   describe result::Mixin do
-    subject(:obj) { Object.new.tap { |o| o.extend(result::Mixin) } }
+    subject(:context) { Object.new.tap { |o| o.extend(result::Mixin) } }
 
     describe '#Success' do
       example 'with plain value' do

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -454,6 +454,10 @@ RSpec.describe(Dry::Monads::Result) do
       it 'raises an ArgumentError on missing value' do
         expect { subject.Failure() }.to raise_error(ArgumentError, 'No value given')
       end
+
+      it 'tracks the caller' do
+        expect(subject.Failure('fail').trace).to include("spec/unit/result_spec.rb")
+      end
     end
   end
 end

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe(Dry::Monads::Task) do
       expect(error).to be_a_failure
       expect(error.failure).to be_a(ZeroDivisionError)
     end
+
+    it 'tracks the caller' do
+      error = task { 1 / 0 }.to_result
+      expect(error.trace).to include("spec/unit/task_spec.rb")
+    end
   end
 
   describe '#to_maybe' do
@@ -80,6 +85,11 @@ RSpec.describe(Dry::Monads::Task) do
     it 'transforms an unsuccessful result to None' do
       error = task { 1 / 0 }.to_maybe
       expect(error).to be_none
+    end
+
+    it 'tracks the caller' do
+      error = task { 1 / 0 }.to_maybe
+      expect(error.trace).to include("spec/unit/task_spec.rb")
     end
   end
 

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -230,11 +230,19 @@ RSpec.describe(Dry::Monads::Try) do
       it 'transforms self to None' do
         expect(subject.to_maybe).to eql(maybe::None.new)
       end
+
+      it 'tracks the caller' do
+        expect(subject.to_maybe.trace).to include("spec/unit/try_spec.rb")
+      end
     end
 
     describe '#to_result' do
       it 'transforms self to Result::Failure' do
         expect(subject.to_result).to eql(failure[division_error])
+      end
+
+      it 'tracks the caller' do
+        expect(subject.to_result.trace).to include("spec/unit/try_spec.rb")
       end
     end
 


### PR DESCRIPTION
This adds caller location to `None`/`Failure` values in order to facilitate debugging of "monad-driven"  code.