### PR TITLE
Add implicit convertion to a monad in do notiation

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -79,7 +79,7 @@ module Dry
               def #{ method }(*)
                 super do |*ms|
                   ms = coerce_to_monad(ms)
-                  unwrapped = ms.map { |m| m.or { halt(m) }.value! }
+                  unwrapped = ms.map { |m| m.to_monad.or { halt(m) }.value! }
                   ms.size == 1 ? unwrapped[0] : unwrapped
                 end
               rescue Halt => e

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -283,6 +283,13 @@ module Dry
         List
       end
 
+      # Returns self.
+      #
+      # @return [Result::Success, Result::Failure]
+      def to_monad
+        self
+      end
+
       private
 
       def coerce(other)

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -54,6 +54,13 @@ module Dry
         self
       end
 
+      # Returns self.
+      #
+      # @return [Maybe::Some, Maybe::None]
+      def to_monad
+        self
+      end
+
       # Returns the Maybe monad.
       # This is how we're doing polymorphism in Ruby 😕
       #

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -36,6 +36,13 @@ module Dry
         self
       end
 
+      # Returns self.
+      #
+      # @return [Result::Success, Result::Failure]
+      def to_monad
+        self
+      end
+
       # Returns the Result monad.
       # This is how we're doing polymorphism in Ruby 😕
       #

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -213,6 +213,13 @@ module Dry
         Task
       end
 
+      # Returns self.
+      #
+      # @return [Maybe::Some, Maybe::None]
+      def to_monad
+        self
+      end
+
       # Applies the stored value to the given argument.
       #
       # @example

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -53,6 +53,13 @@ module Dry
       end
       alias_method :failure?, :error?
 
+      # Returns self.
+      #
+      # @return [Maybe::Some, Maybe::None]
+      def to_monad
+        self
+      end
+
       # Represents a result of a successful execution.
       #
       # @api public

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -289,4 +289,27 @@ RSpec.describe(Dry::Monads::Do) do
       end
     end
   end
+
+  context 'implicit conversions' do
+    before do
+      class Test::ValidationResult
+        def to_monad
+          Dry::Monads::Success(:converted)
+        end
+      end
+
+      class Test::Operation
+        def call(obj)
+          result = yield(obj)
+
+          Success(result)
+        end
+      end
+    end
+
+    it 'implicitly converts an arbitrary object to a monad' do
+      result = Test::ValidationResult.new
+      expect(instance.(result)).to eql(Success(:converted))
+    end
+  end
 end

--- a/spec/shared/monad_spec.rb
+++ b/spec/shared/monad_spec.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples_for 'a monad' do
+  describe '#to_monad' do
+    it 'returns self' do
+      expect(subject.to_monad).to be(subject)
+    end
+  end
+end

--- a/spec/unit/lazy_spec.rb
+++ b/spec/unit/lazy_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe(Dry::Monads::Lazy) do
 
   subject { Lazy { 1 + 2 } }
 
+  it_behaves_like 'a monad'
+
   describe '#value!' do
     it 'forces the computation' do
       run = false

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe(Dry::Monads::List) do
   subject { list[1, 2, 3] }
   let(:empty_list) { list[] }
 
+  it_behaves_like 'a monad'
+
   describe '.coerce' do
     let(:array_like) do
       Object.new.tap do |o|

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe(Dry::Monads::Maybe) do
   describe maybe::Some do
     subject { described_class.new('foo') }
 
+    it_behaves_like 'a monad'
+
     let(:upcased_subject) { described_class.new('FOO') }
 
     it { is_expected.to be_some }
@@ -185,6 +187,8 @@ RSpec.describe(Dry::Monads::Maybe) do
 
   describe maybe::None do
     subject { described_class.new }
+
+    it_behaves_like 'a monad'
 
     it { is_expected.not_to be_some }
     it { is_expected.to be_none }

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe(Dry::Monads::Result) do
   describe result::Success do
     subject { success['foo'] }
 
+    it_behaves_like 'a monad'
+
     let(:upcased_subject) { success['FOO'] }
 
     it { is_expected.to be_success }
@@ -262,6 +264,8 @@ RSpec.describe(Dry::Monads::Result) do
 
   describe result::Failure do
     subject { result::Failure.new('bar') }
+
+    it_behaves_like 'a monad'
 
     it { is_expected.not_to be_success }
 

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe(Dry::Monads::Task) do
     task(&deferred { 1 })
   end
 
+  it_behaves_like 'a monad'
+
   describe '.new' do
     it 'delays the execution' do
       expect(subject.value!).to be 1

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe(Dry::Monads::Try) do
   describe(try::Value) do
     subject { div_value['foo'] }
 
+    it_behaves_like 'a monad'
+
     let(:upcase_value) { div_value['FOO'] }
     let(:upcase_error) { try::Error.new(division_error) }
 
@@ -172,6 +174,8 @@ RSpec.describe(Dry::Monads::Try) do
   describe(try::Error) do
     subject { described_class.new(division_error) }
     other_error = 1 / 0 rescue $ERROR_INFO
+
+    it_behaves_like 'a monad'
 
     let(:upcase_value) { described_class.new([ZeroDivisionError], 'FOO') }
     let(:upcase_error) { try::Error.new(division_error) }


### PR DESCRIPTION
It's an integration point for objects that can be converted to a monadic value such as validation result:

```ruby
class CreateUser
  Schema = Dry::Validation.Schema(....)

  def call(input)
    data = yield Schema.(input)
    Success(repo.create(data))
  end
end
```
Previously, it was `data = yield Schema.(input).to_monad` which is a tiny be longer :)