### PR TITLE
Fix URL to dry-rb.org repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Other requirements:
 2) Follow the style conventions of the surrounding code. In most cases, this is standard ruby style.
 3) Add API documentation if it's a new feature
 4) Update API documentation if it changes an existing feature
-5) Bonus points for sending a PR to [github.com/dry-rb/dry-rb.org](github.com/dry-rb/dry-rb.org) which updates user documentation and guides
+5) Bonus points for sending a PR to [github.com/dry-rb/dry-rb.org](https://github.com/dry-rb/dry-rb.org) which updates user documentation and guides
 
 # Asking for help
 


### PR DESCRIPTION
Hello! I have a tiny documentation fix that I noticed while perusing the site 😄