### PR TITLE
Support ”cherry-picked” requires

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'dry-monads'
+require 'dry/monads/all'
 
 M = Dry::Monads
 

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,4 +1,4 @@
-require 'dry/core/constants'
+require 'dry/monads/undefined'
 require 'dry/monads/maybe'
 require 'dry/monads/try'
 require 'dry/monads/list'
@@ -14,9 +14,6 @@ module Dry
   #
   # @api public
   module Monads
-    # @private
-    Undefined = Dry::Core::Constants::Undefined
-
     # List of monad constructors
     CONSTRUCTORS = [
       Maybe::Mixin::Constructors,

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -15,22 +15,7 @@ module Dry
   # @api public
   module Monads
     # List of monad constructors
-    CONSTRUCTORS = [
-      Maybe::Mixin::Constructors,
-      Validated::Mixin::Constructors,
-      Try::Mixin::Constructors,
-      Task::Mixin::Constructors,
-      Lazy::Mixin::Constructors
-    ].freeze
-
-    # @see Maybe::Some
-    Some = Maybe::Some
-    # @see Maybe::None
-    None = Maybe::None
-    # @see Validated::Valid
-    Valid = Validated::Valid
-    # @see Validated::Invalid
-    Invalid = Validated::Invalid
+    CONSTRUCTORS = [].freeze
 
     extend(*CONSTRUCTORS)
 
@@ -38,6 +23,7 @@ module Dry
     def self.included(base)
       super
 
+      # TODO: Fix once CONSTRUCTORS is empty
       base.include(*CONSTRUCTORS)
     end
   end

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,30 +1,7 @@
-require 'dry/monads/undefined'
-require 'dry/monads/maybe'
-require 'dry/monads/try'
-require 'dry/monads/list'
-require 'dry/monads/task'
-require 'dry/monads/lazy'
-require 'dry/monads/result'
-require 'dry/monads/result/fixed'
-require 'dry/monads/do'
-require 'dry/monads/validated'
-
 module Dry
   # Common, idiomatic monads for Ruby
   #
   # @api public
   module Monads
-    # List of monad constructors
-    CONSTRUCTORS = [].freeze
-
-    extend(*CONSTRUCTORS)
-
-    # @private
-    def self.included(base)
-      super
-
-      # TODO: Fix once CONSTRUCTORS is empty
-      base.include(*CONSTRUCTORS)
-    end
   end
 end

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -17,7 +17,6 @@ module Dry
     # List of monad constructors
     CONSTRUCTORS = [
       Maybe::Mixin::Constructors,
-      Result::Mixin::Constructors,
       Validated::Mixin::Constructors,
       Try::Mixin::Constructors,
       Task::Mixin::Constructors,
@@ -28,10 +27,6 @@ module Dry
     Some = Maybe::Some
     # @see Maybe::None
     None = Maybe::None
-    # @see Result::Success
-    Success = Result::Success
-    # @see Result::Failure
-    Failure = Result::Failure
     # @see Validated::Valid
     Valid = Validated::Valid
     # @see Validated::Invalid
@@ -44,41 +39,6 @@ module Dry
       super
 
       base.include(*CONSTRUCTORS)
-    end
-
-    # Creates a module that has two methods: `Success` and `Failure`.
-    # `Success` is identical to {Result::Mixin::Constructors#Success} and Failure
-    # rejects values that don't conform the value of the `error`
-    # parameter. This is essentially a Result type with the `Failure` part
-    # fixed.
-    #
-    # @example using dry-types
-    #   module Types
-    #     include Dry::Types.module
-    #   end
-    #
-    #   class Operation
-    #     # :user_not_found and :account_not_found are the only
-    #     # values allowed as failure results
-    #     Error =
-    #       Types.Value(:user_not_found) |
-    #       Types.Value(:account_not_found)
-    #
-    #     def find_account(id)
-    #       account = acount_repo.find(id)
-    #
-    #       account ? Success(account) : Failure(:account_not_found)
-    #     end
-    #
-    #     def find_user(id)
-    #       # ...
-    #     end
-    #   end
-    #
-    # @param error [#===] the type of allowed failures
-    # @return [Module]
-    def self.Result(error, **options)
-      Result::Fixed[error, **options]
     end
   end
 end

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -3,5 +3,12 @@ module Dry
   #
   # @api public
   module Monads
+    def self.included(base)
+      if const_defined?(:CONSTRUCTORS)
+        base.include(*CONSTRUCTORS)
+      else
+        raise "Load all monads first with require 'dry/monads/all'"
+      end
+    end
   end
 end

--- a/lib/dry/monads/all.rb
+++ b/lib/dry/monads/all.rb
@@ -1,3 +1,4 @@
+require 'dry/monads'
 require 'dry/monads/do'
 require 'dry/monads/lazy'
 require 'dry/monads/list'
@@ -21,11 +22,5 @@ module Dry
     ].freeze
 
     extend(*CONSTRUCTORS)
-
-    # @private
-    def self.included(base)
-      super
-      base.include(*CONSTRUCTORS)
-    end
   end
 end

--- a/lib/dry/monads/all.rb
+++ b/lib/dry/monads/all.rb
@@ -1,0 +1,31 @@
+require 'dry/monads/do'
+require 'dry/monads/lazy'
+require 'dry/monads/list'
+require 'dry/monads/maybe'
+require 'dry/monads/result'
+require 'dry/monads/result/fixed'
+require 'dry/monads/task'
+require 'dry/monads/try'
+require 'dry/monads/validated'
+
+module Dry
+  module Monads
+    # List of monad constructors
+    CONSTRUCTORS = [
+      Lazy::Mixin::Constructors,
+      Maybe::Mixin::Constructors,
+      Result::Mixin::Constructors,
+      Task::Mixin::Constructors,
+      Try::Mixin::Constructors,
+      Validated::Mixin::Constructors,
+    ].freeze
+
+    extend(*CONSTRUCTORS)
+
+    # @private
+    def self.included(base)
+      super
+      base.include(*CONSTRUCTORS)
+    end
+  end
+end

--- a/lib/dry/monads/conversion_stubs.rb
+++ b/lib/dry/monads/conversion_stubs.rb
@@ -5,7 +5,7 @@ module Dry
         Module.new do
           method_names.each do |name|
             define_method(name) do |*|
-              Methods.send(name)
+              Methods.public_send(name)
             end
           end
         end

--- a/lib/dry/monads/conversion_stubs.rb
+++ b/lib/dry/monads/conversion_stubs.rb
@@ -1,0 +1,31 @@
+module Dry
+  module Monads
+    module ConversionStubs
+      def self.[](*method_names)
+        Module.new do
+          method_names.each do |name|
+            define_method(name) do |*|
+              Methods.send(name)
+            end
+          end
+        end
+      end
+
+      module Methods
+        module_function
+
+        def to_maybe
+          raise "Load Maybe first with require 'dry/monads/maybe'"
+        end
+
+        def to_result
+          raise "Load Result first with require 'dry/monads/result'"
+        end
+
+        def to_validated
+          raise "Load Validated first with require 'dry/monads/validated'"
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/monads/lazy.rb
+++ b/lib/dry/monads/lazy.rb
@@ -74,5 +74,7 @@ module Dry
         include Constructors
       end
     end
+
+    extend Lazy::Mixin::Constructors
   end
 end

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -231,7 +231,7 @@ module Dry
         coerce(value.drop(1))
       end
 
-      # Turns the list into a types one.
+      # Turns the list into a typed one.
       # Type is required for some operations like .traverse.
       #
       # @param type [Monad] Monad instance

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -1,5 +1,4 @@
 require 'dry/equalizer'
-require 'dry/core/deprecations'
 
 require 'dry/monads/maybe'
 require 'dry/monads/task'

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -216,5 +216,22 @@ module Dry
         include Constructors
       end
     end
+
+    class Result
+      class Success < Result
+        # @return [Maybe::Some]
+        def to_maybe
+          Kernel.warn 'Success(nil) transformed to None' if @value.nil?
+          Dry::Monads::Maybe(@value)
+        end
+      end
+
+      class Failure < Result
+        # @return [Maybe::None]
+        def to_maybe
+          Maybe::None.new(trace)
+        end
+      end
+    end
   end
 end

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -217,6 +217,13 @@ module Dry
       end
     end
 
+    extend Maybe::Mixin::Constructors
+
+    # @see Maybe::Some
+    Some = Maybe::Some
+    # @see Maybe::None
+    None = Maybe::None
+
     class Result
       class Success < Result
         undef_method :to_maybe if method_defined?(:to_maybe)

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -247,6 +247,22 @@ module Dry
       end
     end
 
+    class Try
+      class Value < Try
+        # @return [Maybe]
+        def to_maybe
+          Dry::Monads::Maybe(@value)
+        end
+      end
+
+      class Error < Try
+        # @return [Maybe::None]
+        def to_maybe
+          Maybe::None.new(RightBiased::Left.trace_caller)
+        end
+      end
+    end
+
     class Validated
       class Valid < Validated
         # Converts to Maybe::Some

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -219,6 +219,8 @@ module Dry
 
     class Result
       class Success < Result
+        undef_method :to_maybe if method_defined?(:to_maybe)
+
         # @return [Maybe::Some]
         def to_maybe
           Kernel.warn 'Success(nil) transformed to None' if @value.nil?
@@ -227,6 +229,8 @@ module Dry
       end
 
       class Failure < Result
+        undef_method :to_maybe if method_defined?(:to_maybe)
+
         # @return [Maybe::None]
         def to_maybe
           Maybe::None.new(trace)
@@ -235,6 +239,8 @@ module Dry
     end
 
     class Task
+      undef_method :to_maybe if method_defined?(:to_maybe)
+
       # Converts to Maybe. Blocks the current thread if required.
       #
       # @return [Maybe]
@@ -249,6 +255,8 @@ module Dry
 
     class Try
       class Value < Try
+        undef_method :to_maybe if method_defined?(:to_maybe)
+
         # @return [Maybe]
         def to_maybe
           Dry::Monads::Maybe(@value)
@@ -256,6 +264,8 @@ module Dry
       end
 
       class Error < Try
+        undef_method :to_maybe if method_defined?(:to_maybe)
+
         # @return [Maybe::None]
         def to_maybe
           Maybe::None.new(RightBiased::Left.trace_caller)
@@ -265,6 +275,8 @@ module Dry
 
     class Validated
       class Valid < Validated
+        undef_method :to_maybe if method_defined?(:to_maybe)
+
         # Converts to Maybe::Some
         #
         # @return [Maybe::Some]
@@ -274,6 +286,8 @@ module Dry
       end
 
       class Invalid < Validated
+        undef_method :to_maybe if method_defined?(:to_maybe)
+
         # Converts to Maybe::None
         #
         # @return [Maybe::None]

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -233,5 +233,24 @@ module Dry
         end
       end
     end
+
+    class Validated
+      class Valid < Validated
+        # Converts to Maybe::Some
+        #
+        # @return [Maybe::Some]
+        def to_maybe
+          Maybe.pure(value!)
+        end
+      end
+
+      class Invalid < Validated
+        # Converts to Maybe::None
+        #
+        # @return [Maybe::None]
+        def to_maybe
+          Maybe::None.new(RightBiased::Left.trace_caller)
+        end
+      end
   end
 end

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -281,5 +281,6 @@ module Dry
           Maybe::None.new(RightBiased::Left.trace_caller)
         end
       end
+    end
   end
 end

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -234,6 +234,19 @@ module Dry
       end
     end
 
+    class Task
+      # Converts to Maybe. Blocks the current thread if required.
+      #
+      # @return [Maybe]
+      def to_maybe
+        if promise.wait.fulfilled?
+          Maybe::Some.new(promise.value)
+        else
+          Maybe::None.new(RightBiased::Left.trace_caller)
+        end
+      end
+    end
+
     class Validated
       class Valid < Validated
         # Converts to Maybe::Some

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -226,8 +226,6 @@ module Dry
 
     class Result
       class Success < Result
-        undef_method :to_maybe if method_defined?(:to_maybe)
-
         # @return [Maybe::Some]
         def to_maybe
           Kernel.warn 'Success(nil) transformed to None' if @value.nil?
@@ -236,8 +234,6 @@ module Dry
       end
 
       class Failure < Result
-        undef_method :to_maybe if method_defined?(:to_maybe)
-
         # @return [Maybe::None]
         def to_maybe
           Maybe::None.new(trace)
@@ -246,8 +242,6 @@ module Dry
     end
 
     class Task
-      undef_method :to_maybe if method_defined?(:to_maybe)
-
       # Converts to Maybe. Blocks the current thread if required.
       #
       # @return [Maybe]
@@ -262,8 +256,6 @@ module Dry
 
     class Try
       class Value < Try
-        undef_method :to_maybe if method_defined?(:to_maybe)
-
         # @return [Maybe]
         def to_maybe
           Dry::Monads::Maybe(@value)
@@ -271,8 +263,6 @@ module Dry
       end
 
       class Error < Try
-        undef_method :to_maybe if method_defined?(:to_maybe)
-
         # @return [Maybe::None]
         def to_maybe
           Maybe::None.new(RightBiased::Left.trace_caller)
@@ -282,8 +272,6 @@ module Dry
 
     class Validated
       class Valid < Validated
-        undef_method :to_maybe if method_defined?(:to_maybe)
-
         # Converts to Maybe::Some
         #
         # @return [Maybe::Some]
@@ -293,8 +281,6 @@ module Dry
       end
 
       class Invalid < Validated
-        undef_method :to_maybe if method_defined?(:to_maybe)
-
         # Converts to Maybe::None
         #
         # @return [Maybe::None]

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -281,6 +281,19 @@ module Dry
       end
     end
 
+    class Task
+      # Converts to Result. Blocks the current thread if required.
+      #
+      # @return [Result]
+      def to_result
+        if promise.wait.fulfilled?
+          Result::Success.new(promise.value)
+        else
+          Result::Failure.new(promise.reason, RightBiased::Left.trace_caller)
+        end
+      end
+    end
+
     class Validated
       class Valid < Validated
         # Converts to Result::Success

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -282,6 +282,8 @@ module Dry
     end
 
     class Task
+      undef_method :to_result if method_defined?(:to_result)
+
       # Converts to Result. Blocks the current thread if required.
       #
       # @return [Result]
@@ -296,6 +298,8 @@ module Dry
 
     class Try
       class Value < Try
+        undef_method :to_result if method_defined?(:to_result)
+
         # @return [Result::Success]
         def to_result
           Dry::Monads::Result::Success.new(@value)
@@ -303,6 +307,8 @@ module Dry
       end
 
       class Error < Try
+        undef_method :to_result if method_defined?(:to_result)
+
         # @return [Result::Failure]
         def to_result
           Result::Failure.new(exception, RightBiased::Left.trace_caller)
@@ -312,6 +318,8 @@ module Dry
 
     class Validated
       class Valid < Validated
+        undef_method :to_result if method_defined?(:to_result)
+
         # Converts to Result::Success
         #
         # @return [Result::Success]
@@ -321,6 +329,8 @@ module Dry
       end
 
       class Invalid < Validated
+        undef_method :to_result if method_defined?(:to_result)
+
         # Concerts to Result::Failure
         #
         # @return [Result::Failure]

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -1,6 +1,7 @@
 require 'dry/equalizer'
 require 'dry/core/constants'
 
+require 'dry/monads/undefined'
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
 

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -117,12 +117,9 @@ module Dry
           Failure.new(@value, RightBiased::Left.trace_caller)
         end
 
-        # Transforms to Validated
-        #
-        # @return [Validated::Valid]
         def to_validated
-          Validated::Valid.new(value!)
-        end
+          raise "Load Validated first with require 'dry/monads/validated'"
+        end unless method_defined?(:to_validated)
       end
 
       # Represents a value of a failed operation.
@@ -229,12 +226,9 @@ module Dry
           Failure === other && failure === other.failure
         end
 
-        # Transforms to Validated
-        #
-        # @return [Validated::Valid]
         def to_validated
-          Validated::Invalid.new(failure, trace)
-        end
+          raise "Load Validated first with require 'dry/monads/validated'"
+        end unless method_defined?(:to_validated)
       end
 
       # A module that can be included for easier access to Result monads.

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -310,8 +310,6 @@ module Dry
     end
 
     class Task
-      undef_method :to_result if method_defined?(:to_result)
-
       # Converts to Result. Blocks the current thread if required.
       #
       # @return [Result]
@@ -326,8 +324,6 @@ module Dry
 
     class Try
       class Value < Try
-        undef_method :to_result if method_defined?(:to_result)
-
         # @return [Result::Success]
         def to_result
           Dry::Monads::Result::Success.new(@value)
@@ -335,8 +331,6 @@ module Dry
       end
 
       class Error < Try
-        undef_method :to_result if method_defined?(:to_result)
-
         # @return [Result::Failure]
         def to_result
           Result::Failure.new(exception, RightBiased::Left.trace_caller)
@@ -346,8 +340,6 @@ module Dry
 
     class Validated
       class Valid < Validated
-        undef_method :to_result if method_defined?(:to_result)
-
         # Converts to Result::Success
         #
         # @return [Result::Success]
@@ -357,8 +349,6 @@ module Dry
       end
 
       class Invalid < Validated
-        undef_method :to_result if method_defined?(:to_result)
-
         # Concerts to Result::Failure
         #
         # @return [Result::Failure]

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -274,7 +274,7 @@ module Dry
     # @see Result::Failure
     Failure = Result::Failure
 
-        # Creates a module that has two methods: `Success` and `Failure`.
+    # Creates a module that has two methods: `Success` and `Failure`.
     # `Success` is identical to {Result::Mixin::Constructors#Success} and Failure
     # rejects values that don't conform the value of the `error`
     # parameter. This is essentially a Result type with the `Failure` part

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -12,7 +12,7 @@ module Dry
     # @api public
     class Result
       include Transformer
-      include Dry::Monads::ConversionStubs[:to_maybe, :to_validated]
+      include ConversionStubs[:to_maybe, :to_validated]
 
       # @return [Object] Successful result
       attr_reader :success

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -3,7 +3,6 @@ require 'dry/core/constants'
 
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
-require 'dry/monads/maybe'
 
 module Dry
   module Monads
@@ -107,11 +106,9 @@ module Dry
         end
         alias_method :inspect, :to_s
 
-        # @return [Maybe::Some]
         def to_maybe
-          Kernel.warn 'Success(nil) transformed to None' if @value.nil?
-          Dry::Monads::Maybe(@value)
-        end
+          raise "Load Maybe first with require 'dry/monads/maybe'"
+        end unless method_defined?(:to_maybe)
 
         # Transforms to a Failure instance
         #
@@ -206,10 +203,9 @@ module Dry
         end
         alias_method :inspect, :to_s
 
-        # @return [Maybe::None]
         def to_maybe
-          Maybe::None.new(trace)
-        end
+          raise "Load Maybe first with require 'dry/monads/maybe'"
+        end unless method_defined?(:to_maybe)
 
         # Transform to a Success instance
         #

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -1,5 +1,4 @@
 require 'dry/equalizer'
-require 'dry/core/constants'
 
 require 'dry/monads/undefined'
 require 'dry/monads/right_biased'
@@ -280,6 +279,48 @@ module Dry
 
         include Constructors
       end
+    end
+
+    extend Result::Mixin::Constructors
+
+    # @see Result::Success
+    Success = Result::Success
+    # @see Result::Failure
+    Failure = Result::Failure
+
+        # Creates a module that has two methods: `Success` and `Failure`.
+    # `Success` is identical to {Result::Mixin::Constructors#Success} and Failure
+    # rejects values that don't conform the value of the `error`
+    # parameter. This is essentially a Result type with the `Failure` part
+    # fixed.
+    #
+    # @example using dry-types
+    #   module Types
+    #     include Dry::Types.module
+    #   end
+    #
+    #   class Operation
+    #     # :user_not_found and :account_not_found are the only
+    #     # values allowed as failure results
+    #     Error =
+    #       Types.Value(:user_not_found) |
+    #       Types.Value(:account_not_found)
+    #
+    #     def find_account(id)
+    #       account = acount_repo.find(id)
+    #
+    #       account ? Success(account) : Failure(:account_not_found)
+    #     end
+    #
+    #     def find_user(id)
+    #       # ...
+    #     end
+    #   end
+    #
+    # @param error [#===] the type of allowed failures
+    # @return [Module]
+    def self.Result(error, **options)
+      Result::Fixed[error, **options]
     end
 
     class Task

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -280,5 +280,25 @@ module Dry
         include Constructors
       end
     end
+
+    class Validated
+      class Valid < Validated
+        # Converts to Result::Success
+        #
+        # @return [Result::Success]
+        def to_result
+          Result.pure(value!)
+        end
+      end
+
+      class Invalid < Validated
+        # Concerts to Result::Failure
+        #
+        # @return [Result::Failure]
+        def to_result
+          Result::Failure.new(error, RightBiased::Left.trace_caller)
+        end
+      end
+    end
   end
 end

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -294,6 +294,22 @@ module Dry
       end
     end
 
+    class Try
+      class Value < Try
+        # @return [Result::Success]
+        def to_result
+          Dry::Monads::Result::Success.new(@value)
+        end
+      end
+
+      class Error < Try
+        # @return [Result::Failure]
+        def to_result
+          Result::Failure.new(exception, RightBiased::Left.trace_caller)
+        end
+      end
+    end
+
     class Validated
       class Valid < Validated
         # Converts to Result::Success

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -3,6 +3,7 @@ require 'dry/equalizer'
 require 'dry/monads/undefined'
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
+require 'dry/monads/conversion_stubs'
 
 module Dry
   module Monads
@@ -11,6 +12,7 @@ module Dry
     # @api public
     class Result
       include Transformer
+      include Dry::Monads::ConversionStubs[:to_maybe, :to_validated]
 
       # @return [Object] Successful result
       attr_reader :success
@@ -106,20 +108,12 @@ module Dry
         end
         alias_method :inspect, :to_s
 
-        def to_maybe
-          raise "Load Maybe first with require 'dry/monads/maybe'"
-        end unless method_defined?(:to_maybe)
-
         # Transforms to a Failure instance
         #
         # @return [Result::Failure]
         def flip
           Failure.new(@value, RightBiased::Left.trace_caller)
         end
-
-        def to_validated
-          raise "Load Validated first with require 'dry/monads/validated'"
-        end unless method_defined?(:to_validated)
       end
 
       # Represents a value of a failed operation.
@@ -200,10 +194,6 @@ module Dry
         end
         alias_method :inspect, :to_s
 
-        def to_maybe
-          raise "Load Maybe first with require 'dry/monads/maybe'"
-        end unless method_defined?(:to_maybe)
-
         # Transform to a Success instance
         #
         # @return [Result::Success]
@@ -225,10 +215,6 @@ module Dry
         def ===(other)
           Failure === other && failure === other.failure
         end
-
-        def to_validated
-          raise "Load Validated first with require 'dry/monads/validated'"
-        end unless method_defined?(:to_validated)
       end
 
       # A module that can be included for easier access to Result monads.

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -112,16 +112,9 @@ module Dry
       end
       alias_method :then, :bind
 
-      # Converts to Result. Blocks the current thread if required.
-      #
-      # @return [Result]
       def to_result
-        if promise.wait.fulfilled?
-          Result::Success.new(promise.value)
-        else
-          Result::Failure.new(promise.reason, RightBiased::Left.trace_caller)
-        end
-      end
+        raise "Load Result first with require 'dry/monads/result'"
+      end unless method_defined?(:to_result)
 
       # Converts to Maybe. Blocks the current thread if required.
       #

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -1,6 +1,7 @@
 require 'concurrent/promise'
 
 require 'dry/monads/curry'
+require 'dry/monads/conversion_stubs'
 
 module Dry
   module Monads
@@ -68,6 +69,8 @@ module Dry
         end
       end
 
+      include ConversionStubs[:to_maybe, :to_result]
+
       # @api private
       attr_reader :promise
       protected :promise
@@ -111,14 +114,6 @@ module Dry
         self.class.new(promise.flat_map { |value| block.(value).promise })
       end
       alias_method :then, :bind
-
-      def to_result
-        raise "Load Result first with require 'dry/monads/result'"
-      end unless method_defined?(:to_result)
-
-      def to_maybe
-        raise "Load Maybe first with require 'dry/monads/maybe'"
-      end unless method_defined?(:to_result)
 
       # @return [String]
       def to_s
@@ -291,5 +286,7 @@ module Dry
         include Constructors
       end
     end
+
+    extend Task::Mixin::Constructors
   end
 end

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -116,16 +116,9 @@ module Dry
         raise "Load Result first with require 'dry/monads/result'"
       end unless method_defined?(:to_result)
 
-      # Converts to Maybe. Blocks the current thread if required.
-      #
-      # @return [Maybe]
       def to_maybe
-        if promise.wait.fulfilled?
-          Maybe::Some.new(promise.value)
-        else
-          Maybe::None.new(RightBiased::Left.trace_caller)
-        end
-      end
+        raise "Load Maybe first with require 'dry/monads/maybe'"
+      end unless method_defined?(:to_result)
 
       # @return [String]
       def to_s

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -2,7 +2,6 @@ require 'dry/equalizer'
 require 'dry/core/deprecations'
 
 require 'dry/monads/right_biased'
-require 'dry/monads/result'
 
 module Dry
   module Monads
@@ -156,10 +155,9 @@ module Dry
           raise "Load Maybe first with require 'dry/monads/maybe'"
         end unless method_defined?(:to_maybe)
 
-        # @return [Result::Success]
         def to_result
-          Dry::Monads::Result::Success.new(@value)
-        end
+          raise "Load Result first with require 'dry/monads/result'"
+        end unless method_defined?(:to_maybe)
 
         # @return [String]
         def to_s
@@ -184,10 +182,9 @@ module Dry
           raise "Load Maybe first with require 'dry/monads/maybe'"
         end unless method_defined?(:to_maybe)
 
-        # @return [Result::Failure]
         def to_result
-          Result::Failure.new(exception, RightBiased::Left.trace_caller)
-        end
+          raise "Load Result first with require 'dry/monads/result'"
+        end unless method_defined?(:to_maybe)
 
         # @return [String]
         def to_s

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -3,7 +3,6 @@ require 'dry/core/deprecations'
 
 require 'dry/monads/right_biased'
 require 'dry/monads/result'
-require 'dry/monads/maybe'
 
 module Dry
   module Monads
@@ -153,10 +152,9 @@ module Dry
           Error.new(e)
         end
 
-        # @return [Maybe]
         def to_maybe
-          Dry::Monads::Maybe(@value)
-        end
+          raise "Load Maybe first with require 'dry/monads/maybe'"
+        end unless method_defined?(:to_maybe)
 
         # @return [Result::Success]
         def to_result
@@ -182,10 +180,9 @@ module Dry
           @exception = exception
         end
 
-        # @return [Maybe::None]
         def to_maybe
-          Maybe::None.new(RightBiased::Left.trace_caller)
-        end
+          raise "Load Maybe first with require 'dry/monads/maybe'"
+        end unless method_defined?(:to_maybe)
 
         # @return [Result::Failure]
         def to_result

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -2,6 +2,7 @@ require 'dry/equalizer'
 require 'dry/core/deprecations'
 
 require 'dry/monads/right_biased'
+require 'dry/monads/conversion_stubs'
 
 module Dry
   module Monads
@@ -12,6 +13,8 @@ module Dry
     class Try
       # @private
       DEFAULT_EXCEPTIONS = [StandardError].freeze
+
+      include ConversionStubs[:to_maybe, :to_result]
 
       # @return [Exception] Caught exception
       attr_reader :exception
@@ -151,14 +154,6 @@ module Dry
           Error.new(e)
         end
 
-        def to_maybe
-          raise "Load Maybe first with require 'dry/monads/maybe'"
-        end unless method_defined?(:to_maybe)
-
-        def to_result
-          raise "Load Result first with require 'dry/monads/result'"
-        end unless method_defined?(:to_maybe)
-
         # @return [String]
         def to_s
           "Try::Value(#{ @value.inspect })"
@@ -177,14 +172,6 @@ module Dry
         def initialize(exception)
           @exception = exception
         end
-
-        def to_maybe
-          raise "Load Maybe first with require 'dry/monads/maybe'"
-        end unless method_defined?(:to_maybe)
-
-        def to_result
-          raise "Load Result first with require 'dry/monads/result'"
-        end unless method_defined?(:to_maybe)
 
         # @return [String]
         def to_s
@@ -285,5 +272,7 @@ module Dry
         end
       end
     end
+
+    extend Try::Mixin::Constructors
   end
 end

--- a/lib/dry/monads/undefined.rb
+++ b/lib/dry/monads/undefined.rb
@@ -1,0 +1,8 @@
+require 'dry/core/constants'
+
+module Dry
+  module Monads
+    # @private
+    Undefined = Dry::Core::Constants::Undefined
+  end
+end

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -291,5 +291,25 @@ module Dry
         include Constructors
       end
     end
+
+    class Result
+      class Success < Result
+        # Transforms to Validated
+        #
+        # @return [Validated::Valid]
+        def to_validated
+          Validated::Valid.new(value!)
+        end
+      end
+
+      class Failure < Result
+        # Transforms to Validated
+        #
+        # @return [Validated::Valid]
+        def to_validated
+          Validated::Invalid.new(failure, trace)
+        end
+      end
+    end
   end
 end

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -1,5 +1,4 @@
 require 'dry/monads/maybe'
-require 'dry/monads/result'
 
 module Dry
   module Monads
@@ -128,12 +127,9 @@ module Dry
           Maybe.pure(value!)
         end
 
-        # Converts to Result::Success
-        #
-        # @return [Result::Success]
         def to_result
-          Result.pure(value!)
-        end
+          raise "Load Result first with require 'dry/monads/result'"
+        end unless method_defined?(:to_result)
 
         # @param other [Object]
         # @return [Boolean]
@@ -226,12 +222,9 @@ module Dry
           Maybe::None.new(RightBiased::Left.trace_caller)
         end
 
-        # Concerts to Result::Failure
-        #
-        # @return [Result::Failure]
         def to_result
-          Result::Failure.new(error, RightBiased::Left.trace_caller)
-        end
+          raise "Load Result first with require 'dry/monads/result'"
+        end unless method_defined?(:to_result)
 
         # @param other [Object]
         # @return [Boolean]

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -276,8 +276,6 @@ module Dry
 
     class Result
       class Success < Result
-        undef_method :to_validated if method_defined?(:to_validated)
-
         # Transforms to Validated
         #
         # @return [Validated::Valid]
@@ -287,8 +285,6 @@ module Dry
       end
 
       class Failure < Result
-        undef_method :to_validated if method_defined?(:to_validated)
-
         # Transforms to Validated
         #
         # @return [Validated::Valid]

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -1,4 +1,6 @@
-require 'dry/monads/maybe'
+require 'dry/monads/conversion_stubs'
+require 'dry/monads/undefined'
+require 'dry/monads/right_biased'
 
 module Dry
   module Monads
@@ -18,6 +20,8 @@ module Dry
     #   # => Valid(List['London', 'John'])
     #
     class Validated
+      include ConversionStubs[:to_maybe, :to_result]
+
       class << self
         # Wraps a value with `Valid`.
         #
@@ -120,14 +124,6 @@ module Dry
         end
         alias_method :to_s, :inspect
 
-        def to_maybe
-          raise "Load Maybe first with require 'dry/monads/maybe'"
-        end unless method_defined?(:to_maybe)
-
-        def to_result
-          raise "Load Result first with require 'dry/monads/result'"
-        end unless method_defined?(:to_result)
-
         # @param other [Object]
         # @return [Boolean]
         def ===(other)
@@ -212,14 +208,6 @@ module Dry
         end
         alias_method :to_s, :inspect
 
-        def to_maybe
-          raise "Load Maybe first with require 'dry/monads/maybe'"
-        end unless method_defined?(:to_maybe)
-
-        def to_result
-          raise "Load Result first with require 'dry/monads/result'"
-        end unless method_defined?(:to_result)
-
         # @param other [Object]
         # @return [Boolean]
         def ===(other)
@@ -278,6 +266,13 @@ module Dry
         include Constructors
       end
     end
+
+    extend Validated::Mixin::Constructors
+
+    # @see Validated::Valid
+    Valid = Validated::Valid
+    # @see Validated::Invalid
+    Invalid = Validated::Invalid
 
     class Result
       class Success < Result

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -281,6 +281,8 @@ module Dry
 
     class Result
       class Success < Result
+        undef_method :to_validated if method_defined?(:to_validated)
+
         # Transforms to Validated
         #
         # @return [Validated::Valid]
@@ -290,6 +292,8 @@ module Dry
       end
 
       class Failure < Result
+        undef_method :to_validated if method_defined?(:to_validated)
+
         # Transforms to Validated
         #
         # @return [Validated::Valid]

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -120,12 +120,9 @@ module Dry
         end
         alias_method :to_s, :inspect
 
-        # Converts to Maybe::Some
-        #
-        # @return [Maybe::Some]
         def to_maybe
-          Maybe.pure(value!)
-        end
+          raise "Load Maybe first with require 'dry/monads/maybe'"
+        end unless method_defined?(:to_maybe)
 
         def to_result
           raise "Load Result first with require 'dry/monads/result'"
@@ -215,12 +212,9 @@ module Dry
         end
         alias_method :to_s, :inspect
 
-        # Converts to Maybe::None
-        #
-        # @return [Maybe::None]
         def to_maybe
-          Maybe::None.new(RightBiased::Left.trace_caller)
-        end
+          raise "Load Maybe first with require 'dry/monads/maybe'"
+        end unless method_defined?(:to_maybe)
 
         def to_result
           raise "Load Result first with require 'dry/monads/result'"

--- a/spec/integration/all_monads_inclusion_spec.rb
+++ b/spec/integration/all_monads_inclusion_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe "Dry::Monads module mixin" do
+  it "raises an error when all monads are not loaded" do
+    Dry::Monads.send :remove_const, :CONSTRUCTORS
+
+    expect {
+      class Test::MyClass
+        include Dry::Monads
+      end
+    }.to raise_error RuntimeError, %r{Load all monads first}
+
+    re_require "all"
+  end
+
+  it "raises no error when all monads are loaded" do
+    expect {
+      class Test::MyClass
+        include Dry::Monads
+      end
+    }.not_to raise_error
+
+    expect(Test::MyClass.constants).to include(:Success)
+    expect(Test::MyClass.constants).to include(:Failure)
+  end
+end

--- a/spec/integration/conversion_method_stubs.rb
+++ b/spec/integration/conversion_method_stubs.rb
@@ -1,0 +1,40 @@
+RSpec.describe "Conversion method stubs raising errors" do
+  before do
+    @loaded_features = $LOADED_FEATURES.dup
+    $LOADED_FEATURES.delete_if { |path| path.include?("dry/monads") }
+
+    Dry::Monads.constants.each do |const|
+      Dry::Monads.send(:remove_const, const)
+    end
+    Dry.send(:remove_const, :Monads)
+  end
+
+  after do
+    require "dry/monads"
+  end
+
+  describe "Result" do
+    before do
+      require "dry/monads/result"
+    end
+
+    describe "Success" do
+      specify { expect { Dry::Monads::Success('foo').to_maybe }.to raise_error(RuntimeError) }
+      specify { expect { Dry::Monads::Success('foo').to_validated }.to raise_error(RuntimeError) }
+    end
+
+    describe "Failure" do
+      specify { expect { Dry::Monads::Failure('foo').to_maybe }.to raise_error(RuntimeError) }
+      specify { expect { Dry::Monads::Failure('foo').to_validated }.to raise_error(RuntimeError) }
+    end
+  end
+
+  describe "Task" do
+  end
+
+  describe "Try" do
+  end
+
+  describe "Validated" do
+  end
+end

--- a/spec/integration/conversion_method_stubs.rb
+++ b/spec/integration/conversion_method_stubs.rb
@@ -30,11 +30,43 @@ RSpec.describe "Conversion method stubs raising errors" do
   end
 
   describe "Task" do
+    before do
+      require "dry/monads/task"
+    end
+
+    specify { expect { Dry::Monads::Task.new { 'foo' }.to_maybe }.to raise_error(RuntimeError) }
+    specify { expect { Dry::Monads::Task.new { 'foo' }.to_result }.to raise_error(RuntimeError) }
   end
 
   describe "Try" do
+    before do
+      require "dry/monads/try"
+    end
+
+    describe "Success" do
+      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/1 }.to_maybe }.to raise_error(RuntimeError) }
+      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/1 }.to_result }.to raise_error(RuntimeError) }
+    end
+
+    describe "Failure" do
+      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/0 }.to_maybe }.to raise_error(RuntimeError) }
+      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/0 }.to_result }.to raise_error(RuntimeError) }
+    end
   end
 
   describe "Validated" do
+    before do
+      require "dry/monads/validated"
+    end
+
+    describe "Valid" do
+      specify { expect { Dry::Monads::Valid.new('foo').to_maybe }.to raise_error(RuntimeError) }
+      specify { expect { Dry::Monads::Valid.new('foo').to_result }.to raise_error(RuntimeError) }
+    end
+
+    describe "Invalid" do
+      specify { expect { Dry::Monads::Invalid.new('foo').to_maybe }.to raise_error(RuntimeError) }
+      specify { expect { Dry::Monads::Invalid.new('foo').to_result }.to raise_error(RuntimeError) }
+    end
   end
 end

--- a/spec/integration/conversion_stubs_spec.rb
+++ b/spec/integration/conversion_stubs_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Conversion method stubs raising errors" do
   end
 
   after do
-    require "dry/monads"
+    require "dry/monads/all"
   end
 
   describe "Result" do

--- a/spec/integration/conversion_stubs_spec.rb
+++ b/spec/integration/conversion_stubs_spec.rb
@@ -1,72 +1,144 @@
 RSpec.describe "Conversion method stubs raising errors" do
-  before do
-    @loaded_features = $LOADED_FEATURES.dup
-    $LOADED_FEATURES.delete_if { |path| path.include?("dry/monads") }
-
-    Dry::Monads.constants.each do |const|
-      Dry::Monads.send(:remove_const, const)
-    end
-    Dry.send(:remove_const, :Monads)
-  end
-
-  after do
-    require "dry/monads/all"
-  end
-
   describe "Result" do
-    before do
-      require "dry/monads/result"
+    after do
+      re_require "maybe", "validated"
     end
 
     describe "Success" do
-      specify { expect { Dry::Monads::Success('foo').to_maybe }.to raise_error(RuntimeError) }
-      specify { expect { Dry::Monads::Success('foo').to_validated }.to raise_error(RuntimeError) }
+      before do
+        # To simulate files like maybe, validated, etc. not being loaded, we
+        # simply remove the methods they add, and then re-require the files
+        # again afterwards to get the methods back in place (see the `after`
+        # hooks)
+        Dry::Monads::Result::Success.remove_method :to_maybe
+        Dry::Monads::Result::Success.remove_method :to_validated
+      end
+
+      specify "#to_maybe" do
+        expect { Dry::Monads::Success('foo').to_maybe }.to raise_error(RuntimeError)
+      end
+
+      specify "#to_validated" do
+        expect { Dry::Monads::Success('foo').to_validated }.to raise_error(RuntimeError)
+      end
     end
 
     describe "Failure" do
-      specify { expect { Dry::Monads::Failure('foo').to_maybe }.to raise_error(RuntimeError) }
-      specify { expect { Dry::Monads::Failure('foo').to_validated }.to raise_error(RuntimeError) }
+      before do
+        Dry::Monads::Result::Failure.remove_method :to_maybe
+        Dry::Monads::Result::Failure.remove_method :to_validated
+      end
+
+      specify "#to_maybe" do
+        expect { Dry::Monads::Failure('foo').to_maybe }.to raise_error(RuntimeError)
+      end
+
+      specify "#to_validated" do
+        expect { Dry::Monads::Failure('foo').to_validated }.to raise_error(RuntimeError)
+      end
     end
   end
 
   describe "Task" do
     before do
-      require "dry/monads/task"
+      Dry::Monads::Task.remove_method :to_maybe
+      Dry::Monads::Task.remove_method :to_result
     end
 
-    specify { expect { Dry::Monads::Task.new { 'foo' }.to_maybe }.to raise_error(RuntimeError) }
-    specify { expect { Dry::Monads::Task.new { 'foo' }.to_result }.to raise_error(RuntimeError) }
+    after do
+      re_require "maybe", "result"
+    end
+
+    specify "#to_maybe" do
+      expect { Dry::Monads::Task.new { 'foo' }.to_maybe }.to raise_error(RuntimeError)
+    end
+
+    specify "#to_result" do
+      expect { Dry::Monads::Task.new { 'foo' }.to_result }.to raise_error(RuntimeError)
+    end
   end
 
   describe "Try" do
-    before do
-      require "dry/monads/try"
+    after do
+      re_require "maybe", "result"
     end
 
-    describe "Success" do
-      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/1 }.to_maybe }.to raise_error(RuntimeError) }
-      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/1 }.to_result }.to raise_error(RuntimeError) }
+    describe "Value" do
+      before do
+        Dry::Monads::Try::Value.remove_method(:to_maybe)
+        Dry::Monads::Try::Value.remove_method(:to_result)
+      end
+
+      specify "#to_maybe" do
+        expect { Dry::Monads::Try(ZeroDivisionError) { 1/1 }.to_maybe }.to raise_error(RuntimeError)
+      end
+
+      specify "#to_result" do
+        expect { Dry::Monads::Try(ZeroDivisionError) { 1/1 }.to_result }.to raise_error(RuntimeError)
+      end
     end
 
-    describe "Failure" do
-      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/0 }.to_maybe }.to raise_error(RuntimeError) }
-      specify { expect { Dry::Monads::Try(ZeroDivisionError) { 1/0 }.to_result }.to raise_error(RuntimeError) }
+    describe "Error" do
+      before do
+        Dry::Monads::Try::Error.remove_method(:to_maybe)
+        Dry::Monads::Try::Error.remove_method(:to_result)
+      end
+
+      specify "#to_maybe" do
+        expect { Dry::Monads::Try(ZeroDivisionError) { 1/0 }.to_maybe }.to raise_error(RuntimeError)
+      end
+
+      specify "#to_result" do
+        expect { Dry::Monads::Try(ZeroDivisionError) { 1/0 }.to_result }.to raise_error(RuntimeError)
+      end
     end
   end
 
   describe "Validated" do
-    before do
-      require "dry/monads/validated"
+    after do
+      re_require "maybe", "result"
     end
 
     describe "Valid" do
-      specify { expect { Dry::Monads::Valid.new('foo').to_maybe }.to raise_error(RuntimeError) }
-      specify { expect { Dry::Monads::Valid.new('foo').to_result }.to raise_error(RuntimeError) }
+      before do
+        Dry::Monads::Validated::Valid.remove_method(:to_maybe)
+        Dry::Monads::Validated::Valid.remove_method(:to_result)
+      end
+
+      specify "#to_maybe" do
+        expect { Dry::Monads::Valid.new('foo').to_maybe }.to raise_error(RuntimeError)
+      end
+
+      specify "#to_result" do
+        expect { Dry::Monads::Valid.new('foo').to_result }.to raise_error(RuntimeError)
+      end
     end
 
     describe "Invalid" do
-      specify { expect { Dry::Monads::Invalid.new('foo').to_maybe }.to raise_error(RuntimeError) }
-      specify { expect { Dry::Monads::Invalid.new('foo').to_result }.to raise_error(RuntimeError) }
+      before do
+        Dry::Monads::Validated::Invalid.remove_method(:to_maybe)
+        Dry::Monads::Validated::Invalid.remove_method(:to_result)
+      end
+
+      specify "#to_maybe" do
+        expect { Dry::Monads::Invalid.new('foo').to_maybe }.to raise_error(RuntimeError)
+      end
+
+      specify "#to_result" do
+        expect { Dry::Monads::Invalid.new('foo').to_result }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  def re_require(*paths)
+    $LOADED_FEATURES.delete_if { |feature|
+      paths.any? { |path| feature.include?("dry/monads/#{path}.rb") }
+    }
+
+    suppress_warnings do
+      paths.each do |path|
+        require "dry/monads/#{path}"
+      end
     end
   end
 end

--- a/spec/integration/conversion_stubs_spec.rb
+++ b/spec/integration/conversion_stubs_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "Conversion method stubs raising errors" do
         # simply remove the methods they add, and then re-require the files
         # again afterwards to get the methods back in place (see the `after`
         # hooks)
-        Dry::Monads::Result::Success.remove_method :to_maybe
-        Dry::Monads::Result::Success.remove_method :to_validated
+        Dry::Monads::Result::Success.send :remove_method, :to_maybe
+        Dry::Monads::Result::Success.send :remove_method, :to_validated
       end
 
       specify "#to_maybe" do
@@ -25,8 +25,8 @@ RSpec.describe "Conversion method stubs raising errors" do
 
     describe "Failure" do
       before do
-        Dry::Monads::Result::Failure.remove_method :to_maybe
-        Dry::Monads::Result::Failure.remove_method :to_validated
+        Dry::Monads::Result::Failure.send :remove_method, :to_maybe
+        Dry::Monads::Result::Failure.send :remove_method, :to_validated
       end
 
       specify "#to_maybe" do
@@ -41,8 +41,8 @@ RSpec.describe "Conversion method stubs raising errors" do
 
   describe "Task" do
     before do
-      Dry::Monads::Task.remove_method :to_maybe
-      Dry::Monads::Task.remove_method :to_result
+      Dry::Monads::Task.send :remove_method, :to_maybe
+      Dry::Monads::Task.send :remove_method, :to_result
     end
 
     after do
@@ -65,8 +65,8 @@ RSpec.describe "Conversion method stubs raising errors" do
 
     describe "Value" do
       before do
-        Dry::Monads::Try::Value.remove_method(:to_maybe)
-        Dry::Monads::Try::Value.remove_method(:to_result)
+        Dry::Monads::Try::Value.send :remove_method, :to_maybe
+        Dry::Monads::Try::Value.send :remove_method, :to_result
       end
 
       specify "#to_maybe" do
@@ -80,8 +80,8 @@ RSpec.describe "Conversion method stubs raising errors" do
 
     describe "Error" do
       before do
-        Dry::Monads::Try::Error.remove_method(:to_maybe)
-        Dry::Monads::Try::Error.remove_method(:to_result)
+        Dry::Monads::Try::Error.send :remove_method, :to_maybe
+        Dry::Monads::Try::Error.send :remove_method, :to_result
       end
 
       specify "#to_maybe" do
@@ -101,8 +101,8 @@ RSpec.describe "Conversion method stubs raising errors" do
 
     describe "Valid" do
       before do
-        Dry::Monads::Validated::Valid.remove_method(:to_maybe)
-        Dry::Monads::Validated::Valid.remove_method(:to_result)
+        Dry::Monads::Validated::Valid.send :remove_method, :to_maybe
+        Dry::Monads::Validated::Valid.send :remove_method, :to_result
       end
 
       specify "#to_maybe" do
@@ -116,8 +116,8 @@ RSpec.describe "Conversion method stubs raising errors" do
 
     describe "Invalid" do
       before do
-        Dry::Monads::Validated::Invalid.remove_method(:to_maybe)
-        Dry::Monads::Validated::Invalid.remove_method(:to_result)
+        Dry::Monads::Validated::Invalid.send :remove_method, :to_maybe
+        Dry::Monads::Validated::Invalid.send :remove_method, :to_result
       end
 
       specify "#to_maybe" do

--- a/spec/integration/conversion_stubs_spec.rb
+++ b/spec/integration/conversion_stubs_spec.rb
@@ -129,16 +129,4 @@ RSpec.describe "Conversion method stubs raising errors" do
       end
     end
   end
-
-  def re_require(*paths)
-    $LOADED_FEATURES.delete_if { |feature|
-      paths.any? { |path| feature.include?("dry/monads/#{path}.rb") }
-    }
-
-    suppress_warnings do
-      paths.each do |path|
-        require "dry/monads/#{path}"
-      end
-    end
-  end
 end

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe(Dry::Monads::Do) do
-  include Dry::Monads
+  include Dry::Monads::Maybe::Mixin
+  include Dry::Monads::Result::Mixin
   include Dry::Monads::Try::Mixin
   include Dry::Monads::List::Mixin
   include Dry::Monads::Validated::Mixin
@@ -8,7 +9,8 @@ RSpec.describe(Dry::Monads::Do) do
     module Test
       class Operation
         include Dry::Monads::Do.for(:call)
-        include Dry::Monads
+        include Dry::Monads::Maybe::Mixin
+        include Dry::Monads::Result::Mixin
         include Dry::Monads::Try::Mixin
         include Dry::Monads::List::Mixin
         include Dry::Monads::Validated::Mixin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ end
 
 $VERBOSE = true
 
-require 'dry-monads'
+require 'dry/monads/all'
 
 Dir["./spec/shared/**/*.rb"].sort.each { |f| require f }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,13 +30,25 @@ require 'dry/monads/all'
 
 Dir["./spec/shared/**/*.rb"].sort.each { |f| require f }
 
-module Kernel
+module TestHelpers
   def suppress_warnings
     original_verbosity = $VERBOSE
     $VERBOSE = nil
     result = yield
     $VERBOSE = original_verbosity
     return result
+  end
+
+  def re_require(*paths)
+    $LOADED_FEATURES.delete_if { |feature|
+      paths.any? { |path| feature.include?("dry/monads/#{path}.rb") }
+    }
+
+    suppress_warnings do
+      paths.each do |path|
+        require "dry/monads/#{path}"
+      end
+    end
   end
 end
 
@@ -51,6 +63,8 @@ Dry::Core::Deprecations.set_logger!(Logger.new($stdout))
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+
+  config.include TestHelpers
 
   config.after do
     Test.remove_constants


### PR DESCRIPTION
This PR will make it so that any individual file can be required and work as expected (e.g. `require "dry/monads/result"`).

To avoid circular requires, I've started with @flash-gordon's suggestion to make it so that each monad class only provides "stub" implementations of their conversion methods that raise helpful errors, e.g.

```ruby
require "dry/monads/result"

Dry::Monads.Success("hello").to_maybe
# RuntimeError: Load Maybe first with require 'dry/monads/maybe'
```

And the real implementation of each conversion method is provided by the file of the class that is the _target_ of the conversion:

```ruby
require "dry/monads/result"
require "dry/monads/maybe"

Dry::Monads.Success("hello").to_maybe
# => Some("hello")
```

TODO:

- [x] Extract all conversions
- [x] Add tests for errors raised in stub implementations