### PR TITLE
Add Dry::Monads::Unit

### DIFF
--- a/lib/dry/monads/lazy.rb
+++ b/lib/dry/monads/lazy.rb
@@ -60,6 +60,9 @@ module Dry
         # @see Dry::Monads::Lazy
         Lazy = Lazy
 
+        # @see Dry::Monads::Unit
+        Unit = Unit
+
         # Lazy constructors
         module Constructors
           # Lazy computation contructor

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -1,5 +1,6 @@
 require 'dry/core/constants'
 
+require 'dry/monads/unit'
 require 'dry/monads/curry'
 require 'dry/monads/errors'
 
@@ -99,13 +100,13 @@ module Dry
         # otherwise returns the argument.
         #
         # @example happy path
-        #   create_user = Dry::Monads::Right(CreateUser.new)
-        #   name = Right("John")
+        #   create_user = Dry::Monads::Success(CreateUser.new)
+        #   name = Success("John")
         #   create_user.apply(name) # equivalent to CreateUser.new.call("John")
         #
         # @example unhappy path
-        #   name = Left(:name_missing)
-        #   create_user.apply(name) # => Left(:name_missing)
+        #   name = Failure(:name_missing)
+        #   create_user.apply(name) # => Failure(:name_missing)
         #
         # @return [RightBiased::Left,RightBiased::Right]
         def apply(val = Undefined)
@@ -120,6 +121,18 @@ module Dry
         # @return [Boolean]
         def ===(other)
           self.class == other.class && value! === other.value!
+        end
+
+        # Maps the value to Dry::Monads::Unit, useful when you don't care
+        # about the actual value.
+        #
+        # @example
+        #   Dry::Monads::Success(:success).discard
+        #   # => Success(Unit)
+        #
+        # @return [RightBiased::Right]
+        def discard
+          fmap { Unit }
         end
 
         private
@@ -214,6 +227,14 @@ module Dry
         # @return [RightBiased::Left]
         def apply(*)
           self
+        end
+
+        # Returns self back. It exists to keep the interface
+        # identical to that of {RightBiased::Right}.
+        #
+        # @return [RightBiased::Left]
+        def discard
+          fmap { Unit }
         end
       end
     end

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -1,5 +1,6 @@
 require 'concurrent/promise'
 
+require 'dry/monads/unit'
 require 'dry/monads/curry'
 require 'dry/monads/conversion_stubs'
 
@@ -225,6 +226,13 @@ module Dry
         bind { |f| arg.fmap { |v| curry(f).(v) } }
       end
 
+      # Maps a successful result to Unit, effectively discards it
+      #
+      # @return [Task]
+      def discard
+        fmap { Unit }
+      end
+
       private
 
       # @api private
@@ -252,7 +260,11 @@ module Dry
       #
       # @api public
       module Mixin
-        Task = Task # @private
+        # @private
+        Task = Task
+
+        # @see Dry::Monads::Unit
+        Unit = Unit # @private
 
         # Created a mixin with the given executor injected.
         #

--- a/lib/dry/monads/unit.rb
+++ b/lib/dry/monads/unit.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Dry
+  module Monads
+    Unit = Object.new.tap do |unit|
+      def unit.to_s
+        'Unit'
+      end
+
+      def unit.inspect
+        'Unit'
+      end
+    end
+  end
+end

--- a/spec/unit/lazy_spec.rb
+++ b/spec/unit/lazy_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe(Dry::Monads::Lazy) do
-  include Dry::Monads::Lazy::Mixin
+  mixin = Dry::Monads::Lazy::Mixin
+  include mixin
 
   subject { Lazy { 1 + 2 } }
 
@@ -72,6 +73,12 @@ RSpec.describe(Dry::Monads::Lazy) do
       expect(subject.to_s).to eql("Lazy(3)")
 
       expect(Lazy { 1 / 0 }.force.to_s).to eql("Lazy(!#<ZeroDivisionError: divided by 0>)")
+    end
+  end
+
+  describe '#discard' do
+    it 'nullifies the value' do
+      expect(Lazy { 1 }.discard.value!).to be mixin::Unit
     end
   end
 end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe(Dry::Monads::Maybe) do
   maybe = described_class
   some = maybe::Some.method(:new)
   none = maybe::None.new
+  unit = Dry::Monads::Unit
 
   let(:upcase) { :upcase.to_proc }
 
@@ -187,6 +188,12 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(some[10..50]).to be === some[42]
       end
     end
+
+    describe '#discard' do
+      it 'nullifies the value' do
+        expect(some['foo'].discard).to eql(some[unit])
+      end
+    end
   end
 
   describe maybe::None do
@@ -350,6 +357,12 @@ RSpec.describe(Dry::Monads::Maybe) do
 
       it "doesn't match a Some" do
         expect(none).not_to be === some['foo']
+      end
+    end
+
+    describe '#discard' do
+      it 'returns self back' do
+        expect(none.discard).to be none
       end
     end
   end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe(Dry::Monads::Result) do
   validated = Dry::Monads::Validated
   valid = validated::Valid.method(:new)
   invalid = validated::Invalid.method(:new)
+  unit = Dry::Monads::Unit
 
   let(:upcase) { :upcase.to_proc }
 
@@ -273,6 +274,12 @@ RSpec.describe(Dry::Monads::Result) do
         expect(success[10..50]).to be === success[42]
       end
     end
+
+    describe '#discard' do
+      it 'nullifies the value' do
+        expect(success['foo'].discard).to eql(success[unit])
+      end
+    end
   end
 
   describe result::Failure do
@@ -450,6 +457,13 @@ RSpec.describe(Dry::Monads::Result) do
     describe '#to_validated' do
       it 'returns Invalid' do
         expect(subject.to_validated).to eql(invalid.('bar'))
+      end
+    end
+
+    describe '#discard' do
+      it 'returns self back' do
+        m = failure[1]
+        expect(m.discard).to be m
       end
     end
   end

--- a/spec/unit/unit_spec.rb
+++ b/spec/unit/unit_spec.rb
@@ -1,0 +1,8 @@
+require 'dry/monads/unit'
+
+RSpec.describe(Dry::Monads::Unit) do
+  subject { described_class }
+
+  specify('#to_s') { expect(subject.to_s).to eql('Unit') }
+  specify('#inspect') { expect(subject.inspect).to eql('Unit') }
+end


### PR DESCRIPTION
Unit is a direct replacement for `nil` where you care only about type constructor, ignoring the underlying value. For example, I have a few places in my code where I intentionally return `Success(nil)` as a result, here `Success(Unit)` reveals intentions better. Besides it, `Some(nil)` throws an error so you had to use `Some(true)` or something similar instead. Now `Unit` can be used in both cases.