### PR TITLE
Add Do::All

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -110,13 +110,17 @@ module Dry
       def self.wrap_method(target, method)
         target.module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def #{ method }(*)
-            super do |*ms|
-              ms = Do.coerce_to_monad(ms)
-              unwrapped = ms.map { |r|
-                m = r.to_monad
-                m.or { Do.halt(m) }.value!
-              }
-              ms.size == 1 ? unwrapped[0] : unwrapped
+            if block_given?
+              super
+            else
+              super do |*ms|
+                ms = Do.coerce_to_monad(ms)
+                unwrapped = ms.map { |r|
+                  m = r.to_monad
+                  m.or { Do.halt(m) }.value!
+                }
+                ms.size == 1 ? unwrapped[0] : unwrapped
+              end
             end
           rescue Halt => e
             e.result

--- a/lib/dry/monads/do/all.rb
+++ b/lib/dry/monads/do/all.rb
@@ -37,7 +37,9 @@ module Dry
         def self.included(base)
           super
 
-          base.extend(MethodTracker.new(Module.new))
+          tracker = MethodTracker.new(Module.new)
+          base.extend(tracker)
+          base.instance_methods(false).each { |m| tracker.wrap_method(m) }
         end
       end
     end

--- a/lib/dry/monads/do/all.rb
+++ b/lib/dry/monads/do/all.rb
@@ -3,6 +3,57 @@ require 'dry/monads/do'
 module Dry
   module Monads
     module Do
+      # Do::All automatically wraps methods defined in a class with an unwrapping block.
+      # Similar to what `Do.for(...)` does except wraps every method so you don't have
+      # to list them explicitly.
+      #
+      # @example annotated example
+      #
+      #   require 'dry/monads/do/all'
+      #   require 'dry/monads/result'
+      #
+      #   class CreateUser
+      #     include Dry::Monads::Do::All
+      #     include Dry::Monads::Result::Mixin
+      #
+      #     def call(params)
+      #       # Unwrap a monadic value using an implicitly passed block
+      #       # if `validates` returns Failure, the execution will be halted
+      #       values = yield validate(params)
+      #       user = create_user(values)
+      #       # If another block is passed to a method then takes
+      #       # precedence over the unwrapping block
+      #       safely_subscribe(values[:email]) { Logger.info("Already subscribed") }
+      #
+      #       Success(user)
+      #     end
+      #
+      #     def validate(params)
+      #       if params.key?(:email)
+      #         Success(email: params[:email])
+      #       else
+      #         Failure(:no_email)
+      #       end
+      #     end
+      #
+      #     def create_user(user)
+      #       # Here a block is passed to the method but we don't use it
+      #       UserRepo.new.add(user)
+      #     end
+      #
+      #     def safely_subscribe(email)
+      #       repo = SubscriptionRepo.new
+      #
+      #       if repo.subscribed?(email)
+      #          # This calls the logger because a block
+      #          # explicitly passed from `call`
+      #          yield
+      #       else
+      #         repo.subscribe(email)
+      #       end
+      #     end
+      #   end
+      #
       module All
         # @private
         class MethodTracker < Module
@@ -33,7 +84,7 @@ module Dry
           end
         end
 
-        # @api public
+        # @private
         def self.included(base)
           super
 

--- a/lib/dry/monads/do/all.rb
+++ b/lib/dry/monads/do/all.rb
@@ -1,0 +1,45 @@
+require 'dry/monads/do'
+
+module Dry
+  module Monads
+    module Do
+      module All
+        # @private
+        class MethodTracker < Module
+          attr_reader :wrappers
+
+          def initialize(wrappers)
+            super()
+
+            @wrappers = wrappers
+            tracker = self
+
+            module_eval do
+              define_method(:method_added) do |method|
+                super(method)
+
+                tracker.wrap_method(method)
+              end
+            end
+          end
+
+          def extend_object(target)
+            super
+            target.prepend(wrappers)
+          end
+
+          def wrap_method(method)
+            Do.wrap_method(wrappers, method)
+          end
+        end
+
+        # @api public
+        def self.included(base)
+          super
+
+          base.extend(MethodTracker.new(Module.new))
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/do_all_spec.rb
+++ b/spec/integration/do_all_spec.rb
@@ -1,0 +1,26 @@
+require 'dry/monads/result'
+require 'dry/monads/do/all'
+
+RSpec.describe(Dry::Monads::Do::All) do
+  let(:mixin) { described_class }
+  result_mixin = Dry::Monads::Result::Mixin
+  include result_mixin
+
+  it 'wraps arbitrary methods defined _after_ mixing in' do
+    spec = self
+    klass = Class.new {
+      include spec.mixin
+
+      def sum(a, b)
+        c = yield(a) + yield(b)
+        Success(c)
+      end
+    }.tap { |c| c.include(result_mixin) }
+
+    adder = klass.new
+
+    expect(adder.sum(Success(1), Success(2))).to eql(Success(3))
+    expect(adder.sum(Success(1), Failure(2))).to eql(Failure(2))
+    expect(adder.sum(Failure(1), Success(2))).to eql(Failure(1))
+  end
+end

--- a/spec/integration/do_all_spec.rb
+++ b/spec/integration/do_all_spec.rb
@@ -23,4 +23,21 @@ RSpec.describe(Dry::Monads::Do::All) do
     expect(adder.sum(Success(1), Failure(2))).to eql(Failure(2))
     expect(adder.sum(Failure(1), Success(2))).to eql(Failure(1))
   end
+
+  it 'wraps already defined method' do
+    klass = Class.new {
+      def sum(a, b)
+        c = yield(a) + yield(b)
+        Success(c)
+      end
+    }.tap { |c|
+      c.include mixin
+      c.include(result_mixin)
+    }
+
+    adder = klass.new
+
+    expect(adder.sum(Success(1), Success(2))).to eql(Success(3))
+
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,6 +63,7 @@ Dry::Core::Deprecations.set_logger!(Logger.new($stdout))
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.filter_run_when_matching :focus
 
   config.include TestHelpers
 


### PR DESCRIPTION
`Do::All` passes a block to all methods so you don't have to specify them explicitly in `for`.

```ruby
require 'dry/monads/do/all'
require 'dry/monads/result'

class Adder
  include Dry::Monads::Do::All
  include Dry::Monads::Result::Mixin

  def sum(a, b)
    c = yield(a) + yield(b)
    Success(c)
  end
end
```