### PR TITLE
Add .to_proc for classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# next-release
+
+## Added
+
+* `to_proc` was added to value constructors (flash-gordon)
+  ```ruby
+  [1, 2, 3].map(&Some) # => [Some(1), Some(2), Some(3)]
+  ```
+
+[Compare v1.0.0...master](https://github.com/dry-rb/dry-monads/compare/v1.0.0...master)
+
 # v1.0.0 2018-06-26
 
 ## Added

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -37,6 +37,13 @@ module Dry
         def pure(value = Undefined, &block)
           Some.new(Undefined.default(value, block))
         end
+
+        # Reutrns a Some wrapper converted to a block
+        #
+        # @return [Proc]
+        def to_proc
+          @to_proc ||= method(:coerce).to_proc
+        end
       end
 
       # Returns true for an instance of a {Maybe::None} monad.

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -123,6 +123,13 @@ module Dry
         include RightBiased::Left
         include Dry::Equalizer(:failure)
 
+        # Returns a constructor proc
+        #
+        # @return [Proc]
+        def self.to_proc
+          @to_proc ||= method(:new).to_proc
+        end
+
         # Line where the value was constructed
         #
         # @return [String]

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -14,6 +14,15 @@ module Dry
       module Right
         include Dry::Core::Constants
 
+        # @private
+        def self.included(m)
+          super
+
+          def m.to_proc
+            @to_proc ||= method(:new).to_proc
+          end
+        end
+
         # Unwraps the underlying value
         #
         # @return [Object]

--- a/spec/integration/maybe_spec.rb
+++ b/spec/integration/maybe_spec.rb
@@ -152,6 +152,27 @@ RSpec.describe(Dry::Monads::Maybe) do
     end
   end
 
+  context '.to_proc' do
+    let(:operation) do
+      class Test::Operation
+        include Dry::Monads::Maybe::Mixin
+
+        def call(value)
+          [
+            value.yield_self(&Maybe),
+            value.yield_self(&Some),
+          ]
+        end
+      end
+
+      Test::Operation.new
+    end
+
+    it 'can be used for constants' do
+      expect(operation.('foo')).to eql([Some('foo'), Some('foo')])
+    end
+  end
+
   describe 'matching' do
     let(:match) do
       -> value do

--- a/spec/integration/maybe_spec.rb
+++ b/spec/integration/maybe_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe(Dry::Monads::Maybe) do
 
         def call(value)
           [
-            value.yield_self(&Maybe),
-            value.yield_self(&Some),
+            value.map(&Maybe),
+            value.map(&Some),
           ]
         end
       end
@@ -169,7 +169,7 @@ RSpec.describe(Dry::Monads::Maybe) do
     end
 
     it 'can be used for constants' do
-      expect(operation.('foo')).to eql([Some('foo'), Some('foo')])
+      expect(operation.(['foo'])).to eql([[Some('foo')], [Some('foo')]])
     end
   end
 

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe(Dry::Monads::Result) do
 
         def call(value)
           [
-            value.yield_self(&Success),
-            value.yield_self(&Failure)
+            value.map(&Success),
+            value.map(&Failure)
           ]
         end
       end
@@ -59,7 +59,7 @@ RSpec.describe(Dry::Monads::Result) do
     end
 
     it 'can be used for constants' do
-      expect(operation.('foo')).to eql([Success('foo'), Failure('foo')])
+      expect(operation.(['foo'])).to eql([[Success('foo')], [Failure('foo')]])
     end
   end
 end

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -41,4 +41,25 @@ RSpec.describe(Dry::Monads::Result) do
       expect(Success(Some(Integer))).not_to be === Success(None())
     end
   end
+
+  context '.to_proc' do
+    let(:operation) do
+      class Test::Operation
+        include Dry::Monads::Success::Mixin
+
+        def call(value)
+          [
+            value.yield_self(&Success),
+            value.yield_self(&Failure)
+          ]
+        end
+      end
+
+      Test::Operation.new
+    end
+
+    it 'can be used for constants' do
+      expect(operation.('foo')).to eql([Success('foo'), Failure('foo')])
+    end
+  end
 end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe(Dry::Monads::Maybe) do
     let(:pure) { some }
   end
 
+  describe maybe do
+    describe '.to_proc' do
+      it 'returns a block for coerce' do
+        expect(maybe.to_proc.('foo')).to eql(some['foo'])
+        expect(maybe.to_proc.(nil)).to eql(none)
+      end
+    end
+  end
+
   describe maybe::Some do
     subject { described_class.new('foo') }
 
@@ -29,6 +38,12 @@ RSpec.describe(Dry::Monads::Maybe) do
 
     it 'has custom inspection' do
       expect(subject.inspect).to eql('Some("foo")')
+    end
+
+    describe '.to_proc' do
+      it 'returns a constructor block' do
+        expect(maybe::Some.to_proc.('foo')).to eql(subject)
+      end
     end
 
     describe '#bind' do


### PR DESCRIPTION
It's quite a natural addition, all constants are actually data constructors. Adding `to_proc` allows easier treat them as a regular function.

Here's some close-to-real-life piece of code I have:

```ruby
include Dry::Monads::Result::Mixin

def call(...)
  ...
  values.each_with_object({}) { ... }.then(&Success)
end
```

`then` is from ruby 2.6 but we'll be ready :)