### PR TITLE
[GH-65] List::Validated doesn't traverse errors properly

### DIFF
--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -163,7 +163,12 @@ module Dry
         #   @return [Validated::Invalid]
         #
         def apply(val = Undefined)
-          Undefined.default(val) { yield }.alt_map { |v| @error + v }
+          applied_value = Undefined.default(val) { yield }
+          if applied_value.is_a?(Invalid)
+            applied_value.alt_map { |errors| @error + errors }
+          else
+            self
+          end
         end
 
         # Lifts a block/proc over Invalid

--- a/spec/integration/list_spec.rb
+++ b/spec/integration/list_spec.rb
@@ -39,5 +39,15 @@ RSpec.describe(Dry::Monads::List) do
 
       expect(errors.traverse).to eql(Valid(list["john@doe.me", "John"]))
     end
+
+    context 'when there are valid and invalid items' do
+      it 'traverses errors' do
+        errors = list::Validated[
+          Valid('John'), Invalid(:no_email), Valid('Doe'), Invalid(:no_name), Valid('john@doe.me')
+        ]
+
+        expect(errors.traverse).to eql(Invalid(list[:no_email, :no_name]))
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixed the issue when List::Validated, which contains mixed items (Valid, Invalid), didn't traverse all errors.

https://github.com/dry-rb/dry-monads/issues/65