### PR TITLE
[RFC] Adds === ability to Maybe and Result types

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -106,6 +106,16 @@ module Dry
           self.class.coerce(bind(*args, &block))
         end
 
+        # Checks to see if the other value is of type Some, and the value
+        # inside case matches our value
+        #
+        # @param other [Any]
+        #
+        # @return [Boolean]
+        def ===(other)
+          other.is_a?(Some) && @value === other.value!
+        end
+
         # @return [String]
         def to_s
           "Some(#{ @value.inspect })"
@@ -168,6 +178,16 @@ module Dry
           'None'
         end
         alias_method :inspect, :to_s
+
+        # Checks to see if the other value is of type None, and the value
+        # inside case matches our value
+        #
+        # @param other [Any]
+        #
+        # @return [Boolean]
+        def ===(other)
+          other.is_a?(None)
+        end
 
         # @api private
         def eql?(other)

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -108,6 +108,16 @@ module Dry
         end
         alias_method :inspect, :to_s
 
+        # Checks to see if the other value is of type Success, and the value
+        # inside case matches our value
+        #
+        # @param other [Any]
+        #
+        # @return [Boolean]
+        def ===(other)
+          other.is_a?(Success) && @value === other.value!
+        end
+
         # Transforms to a Failure instance
         #
         # @return [Result::Failure]


### PR DESCRIPTION
This is a quick RFC, and raising a question: Should there be a lifted `===` for flexibility in the Ruby API?

This will allow for the following:

```ruby
Some(Integer) === Some(1)
Some(1..10) === Some(1)

some_value = Some(1)

case some_value
when Some(Integer) then some_value.value!
when None then some_value.value_or(ReasonableDefault)
end
```

I'd be curious to get all of your opinions on this use-case before trying it against the other monads.