### PR TITLE
Make source code a little bit more beginner-friendly

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -118,9 +118,9 @@ module Dry
       end
 
       # @private
-      def self.wrap_method(target, method)
+      def self.wrap_method(target, method_name)
         target.module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-          def #{ method }(*)
+          def #{ method_name }(*)
             if block_given?
               super
             else

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -76,7 +76,7 @@ module Dry
       # @return [Module]
       def self.for(*methods)
         mod = Module.new do
-          methods.each { |m| Do.wrap_method(self, m) }
+          methods.each { |method_name| Do.wrap_method(self, method_name) }
         end
 
         Module.new do
@@ -103,17 +103,18 @@ module Dry
       end
 
       # @private
-      def self.coerce_to_monad(ms)
-        return ms if ms.size != 1
+      def self.coerce_to_monad(monads)
+        return monads if monads.size != 1
 
-        fst = ms[0]
+        first = monads[0]
 
-        case fst
-        when Array, List
-          list = fst.is_a?(Array) ? List.coerce(fst) : fst
-          [list.traverse]
+        case first
+        when Array
+          [List.coerce(first).traverse]
+        when List
+          [first.traverse]
         else
-          ms
+          monads
         end
       end
 
@@ -124,13 +125,13 @@ module Dry
             if block_given?
               super
             else
-              super do |*ms|
-                ms = Do.coerce_to_monad(ms)
-                unwrapped = ms.map { |r|
-                  m = r.to_monad
-                  m.or { Do.halt(m) }.value!
+              super do |*monads|
+                monads = Do.coerce_to_monad(monads)
+                unwrapped = monads.map { |result|
+                  monad = result.to_monad
+                  monad.or { Do.halt(monad) }.value!
                 }
-                ms.size == 1 ? unwrapped[0] : unwrapped
+                monads.size == 1 ? unwrapped[0] : unwrapped
               end
             end
           rescue Halt => e

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -299,6 +299,8 @@ module Dry
     #       Types.Value(:user_not_found) |
     #       Types.Value(:account_not_found)
     #
+    #     include Dry::Monads::Result(Error)
+    #
     #     def find_account(id)
     #       account = acount_repo.find(id)
     #

--- a/lib/dry/monads/unit.rb
+++ b/lib/dry/monads/unit.rb
@@ -2,6 +2,22 @@
 
 module Dry
   module Monads
+    # Unit is a special object you can use whenever your computations don't
+    # return any payload. Previously, if your function ran a side-effect
+    # and returned no meaningful value, you had to return things like
+    # Success(nil), Success([]), Success({}), Maybe(""), Success(true) and
+    # so forth.
+    #
+    # You should use Unit if you wish to return an empty monad.
+    #
+    # @example with Result
+    #   Success(Unit)
+    #   Failure(Unit)
+    #
+    # @example with Maybe
+    #   Maybe(Unit)
+    #   => Some(Unit)
+    #
     Unit = Object.new.tap do |unit|
       def unit.to_s
         'Unit'

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe(Dry::Monads::Do) do
     end
   end
 
-  context 'yielding multiple values' do
+  context 'yielding multiple arguments' do
     context 'success' do
       before do
         klass.class_eval do
@@ -291,6 +291,24 @@ RSpec.describe(Dry::Monads::Do) do
       it 'returns the first failure case' do
         expect(instance.call).to eql(Failure(1))
       end
+    end
+  end
+
+  context 'passing procs' do
+    before do
+      class Test::Operation
+        def call(&block)
+          result = yield Success(:heya)
+
+          Success(result)
+        end
+      end
+    end
+
+    it 'just calls the passed block, ignoring the do notation' do
+      expect(
+        instance.call { Failure(:foo) }
+      ).to eql(Success(Failure(:foo)))
     end
   end
 

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -226,6 +226,40 @@ RSpec.describe(Dry::Monads::Do) do
     end
   end
 
+  context 'yielding multiple values' do
+    context 'success' do
+      before do
+        klass.class_eval do
+          def call
+            result = yield Success(1), Success(2)
+
+            Success(result)
+          end
+        end
+      end
+
+      it 'casts the given parameters to an array and traverses it' do
+        expect(instance.call).to eql(Success([1, 2]))
+      end
+    end
+
+    context 'failure' do
+      before do
+        klass.class_eval do
+          def call
+            result = yield Success(0), Failure(1), Failure(2)
+
+            Success(result)
+          end
+        end
+      end
+
+      it 'returns the first failure case' do
+        expect(instance.call).to eql(Failure(1))
+      end
+    end
+  end
+
   context 'yielding arrays' do
     context 'success' do
       before do


### PR DESCRIPTION
So that's a small collection of tiny changes I've made while exploring source code. 

Those things do not add new functionality, but potentially improve quality of life for new people coming to dry-monads.

Each change was just too small to be published in separate PRs. So, here we go:

## `Do#wrap_method` now accepts `method_name` instead of `method`

I once decided to `step` into `Do` notation using `pry`. I couldn't get the variable named `method` because language just called the method `method`. 

## `Do` code is not so obfuscated now

It used to have quite a lot of abbreviations and single-letter variables, which were confusing. Renamed them for improved clearance.

Also rewrote case statement in `coerce_to_monad`. Not sure if it is really beneficial, but it's definitely easier to read and understand

## Added missing line in `Result(Errors)` docs

Not much to say

## Wrote some in-code docs for Unit

Were missing, just wrote something

## Wrote two groups of specs for `Do` notation

I didn't see any specs that would cover the case when you pass a block to a function wrapped in `Do`. So I wrote them, practically documenting the behavior.

The same goes for yielding multiple values in Do. We had specs for yielding an array, but never did for code like `yield Success(:a), Failure(:b)`. Now we do


