### PR TITLE
Use Unit as a default argument for Success(), Failure(), Some()

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -4,6 +4,7 @@ require 'dry/core/deprecations'
 
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
+require 'dry/monads/unit'
 
 module Dry
   module Monads
@@ -87,9 +88,9 @@ module Dry
         include Dry::Equalizer(:value!)
         include RightBiased::Right
 
-        def initialize(value)
+        def initialize(value = Undefined)
           raise ArgumentError, 'nil cannot be some' if value.nil?
-          @value = value
+          @value = Undefined.default(value, Unit)
         end
 
         # Does the same thing as #bind except it also wraps the value
@@ -209,8 +210,7 @@ module Dry
           #   @return [Maybe::Some]
           #
           def Some(value = Undefined, &block)
-            v = Undefined.default(value, block)
-            raise ArgumentError, 'No value given' if !value.nil? && v.nil?
+            v = Undefined.default(value, block || Unit)
             Some.new(v)
           end
 

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -4,6 +4,7 @@ require 'dry/monads/undefined'
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
 require 'dry/monads/conversion_stubs'
+require 'dry/monads/unit'
 
 module Dry
   module Monads
@@ -248,8 +249,7 @@ module Dry
           #   @return [Result::Success]
           #
           def Success(value = Undefined, &block)
-            v = Undefined.default(value, block)
-            raise ArgumentError, 'No value given' if !value.nil? && v.nil?
+            v = Undefined.default(value, block || Unit)
             Success.new(v)
           end
 
@@ -264,8 +264,7 @@ module Dry
           #   @return [Result::Failure]
           #
           def Failure(value = Undefined, &block)
-            v = Undefined.default(value, block)
-            raise ArgumentError, 'No value given' if !value.nil? && v.nil?
+            v = Undefined.default(value, block || Unit)
             Failure.new(v, RightBiased::Left.trace_caller)
           end
         end

--- a/spec/integration/monads_spec.rb
+++ b/spec/integration/monads_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe(Dry::Monads) do
   valid = validated::Valid.method(:new)
   invalid = validated::Invalid.method(:new)
 
+  unit = Dry::Monads::Unit
+
   describe 'Maybe' do
     describe '.Maybe' do
       describe 'mapping to Some' do
@@ -47,7 +49,7 @@ RSpec.describe(Dry::Monads) do
       end
 
       example 'using without values produces an error' do
-        expect { m.Some() }.to raise_error(ArgumentError, 'No value given')
+        expect(m.Some()).to eql(some[unit])
       end
     end
 

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
 
       it 'raises an ArgumentError on missing value' do
-        expect { subject.Some() }.to raise_error(ArgumentError, 'No value given')
+        expect(subject.Some()).to eql(some[unit])
       end
     end
 

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -481,8 +481,8 @@ RSpec.describe(Dry::Monads::Result) do
         expect(subject.Success(&block)).to eql(success[block])
       end
 
-      it 'raises an ArgumentError on missing value' do
-        expect { subject.Success() }.to raise_error(ArgumentError, 'No value given')
+      it 'returns Unit when no value given' do
+        expect(subject.Success()).to eql(success[unit])
       end
     end
 
@@ -497,7 +497,7 @@ RSpec.describe(Dry::Monads::Result) do
       end
 
       it 'raises an ArgumentError on missing value' do
-        expect { subject.Failure() }.to raise_error(ArgumentError, 'No value given')
+        expect(subject.Failure()).to eql(failure[unit])
       end
 
       it 'tracks the caller' do


### PR DESCRIPTION
I think it's a nice way to avoid things like `Success(nil)`. We already had `Unit` but the ergonomics wasn't ideal.

```ruby
include Dry::Monads::Result::Mixin
include Dry::Monads::Do

def call
  yield do_1
  yield do_2

  Success()
end
```