### PR TITLE
Add RightBiased#flatten and RightBiased#and

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.2.0 to-be-released
 
+## BREAKING CHANGES
+
+* Support for Ruby 2.2 was dropped. Ruby 2.2 reached its EOL on March 31, 2018.
+
 ## Added
 
 * `List#collect` gathers `Some` values from the list (flash-gordon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,34 @@
   List[Some(5), None(), Some(3)].collect.map { |x| x * 2 }
   # => [10, 6]
   ```
-  
+
+* Right-biased monads got `#flatten` and `#and` (falsh-gordon)
+
+  `#flatten` removes one level of monadic structure, it's useful when you're dealing with things like `Maybe` of `Maybe` of something:
+  ```ruby
+  include Dry::Monads::Maybe::Mixin
+
+  Some(Some(1)).flatten # => Some(1)
+  Some(None()).flatten # => None
+  None().flatten # => None
+  ```
+  In contrast to `Array#flatten`, dry-monads' version removes only 1 level of nesting, that is always acts as `Array#flatten(1)`:
+  ```ruby
+  Some(Some(Some(1))).flatten # => Some(Some(1))
+  ```
+  `#and` is handy for combining two monadic values and working with them at once:
+  ```ruby
+  include Dry::Monads::Maybe::Mixin
+
+  # using block
+  Some(5).and(Some(3)) { |x, y| x + y } # => Some(8)
+  # without block
+  Some(5).and(Some(3)) # => Some([5, 3])
+  # other cases
+  Some(5).and(None()) # => None()
+  None().and(Some(5)) # => None()
+  ```
+
 [Compare v1.1.0...master](https://github.com/dry-rb/dry-monads/compare/v1.1.0...master)
 
 # v1.1.0 2018-10-16

--- a/dry-monads.gemspec
+++ b/dry-monads.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = ">= 2.2.0"
+  spec.required_ruby_version = ">= 2.3.0"
   spec.add_dependency 'dry-equalizer'
   spec.add_dependency 'dry-core', '~> 0.4', '>= 0.4.4'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -144,6 +144,19 @@ module Dry
           fmap { Unit }
         end
 
+        # Removes one level of monad structure by joining two values.
+        #
+        # @example
+        #   include Dry::Monads::Result::Mixin
+        #   Success(Success(5)).flatten # => Success(5)
+        #   Success(Failure(:not_a_number)).flatten # => Failure(:not_a_number)
+        #   Failure(:not_a_number).flatten # => Failure(:not_a_number)
+        #
+        # @return [RightBiased::Right,RightBiased::Left]
+        def flatten
+          bind(&:itself)
+        end
+
         private
 
         # @api private
@@ -244,6 +257,19 @@ module Dry
         # @return [RightBiased::Left]
         def discard
           fmap { Unit }
+        end
+
+        # Removes one level of monad structure by joining two values.
+        #
+        # @example
+        #   include Dry::Monads::Result::Mixin
+        #   Success(Success(5)).flatten # => Success(5)
+        #   Success(Failure(:not_a_number)).flatten # => Failure(:not_a_number)
+        #   Failure(:not_a_number).flatten # => Failure(:not_a_number)
+        #
+        # @return [RightBiased::Right,RightBiased::Left]
+        def flatten
+          self
         end
       end
     end

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -157,6 +157,34 @@ module Dry
           bind(&:itself)
         end
 
+        # Combines the wrapped value with another monadic value.
+        # If both values are right-sided, yields a block and passes a tuple
+        # of values there. If no block given, returns a tuple of values wrapped with
+        # a monadic structure.
+        #
+        # @example
+        #   include Dry::Monads::Result::Mixin
+        #
+        #   Success(3).and(Success(5)) # => Success([3, 5])
+        #   Success(3).and(Failure(:not_a_number)) # => Failure(:not_a_number)
+        #   Failure(:not_a_number).and(Success(5)) # => Failure(:not_a_number)
+        #   Success(3).and(Success(5)) { |a, b| a + b } # => Success(8)
+        #
+        # @param mb [RightBiased::Left,RightBiased::Right]
+        #
+        # @return [RightBiased::Left,RightBiased::Right]
+        def and(mb)
+          bind do |a|
+            mb.fmap do |b|
+              if block_given?
+                yield([a, b])
+              else
+                [a, b]
+              end
+            end
+          end
+        end
+
         private
 
         # @api private
@@ -256,19 +284,22 @@ module Dry
         #
         # @return [RightBiased::Left]
         def discard
-          fmap { Unit }
+          self
         end
 
-        # Removes one level of monad structure by joining two values.
+        # Returns self back. It exists to keep the interface
+        # identical to that of {RightBiased::Right}.
         #
-        # @example
-        #   include Dry::Monads::Result::Mixin
-        #   Success(Success(5)).flatten # => Success(5)
-        #   Success(Failure(:not_a_number)).flatten # => Failure(:not_a_number)
-        #   Failure(:not_a_number).flatten # => Failure(:not_a_number)
-        #
-        # @return [RightBiased::Right,RightBiased::Left]
+        # @return [RightBiased::Left]
         def flatten
+          self
+        end
+
+        # Returns self back. It exists to keep the interface
+        # identical to that of {RightBiased::Right}.
+        #
+        # @return [RightBiased::Left]
+        def and(_)
           self
         end
       end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -209,6 +209,16 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(some['foo'].discard).to eql(some[unit])
       end
     end
+
+    describe '#flatten' do
+      it 'removes one level of monad' do
+        expect(some[some['foo']].flatten).to eql(some['foo'])
+      end
+
+      it 'returns None for Some(None)' do
+        expect(some[none].flatten).to eql(none)
+      end
+    end
   end
 
   describe maybe::None do
@@ -378,6 +388,12 @@ RSpec.describe(Dry::Monads::Maybe) do
     describe '#discard' do
       it 'returns self back' do
         expect(none.discard).to be none
+      end
+    end
+
+    describe '#flatten' do
+      it 'always return None' do
+        expect(none.flatten).to eql(none)
       end
     end
   end

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -219,6 +219,21 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(some[none].flatten).to eql(none)
       end
     end
+
+    describe '#and' do
+      it 'joins two maybe values with a block' do
+        expect(some['foo'].and(some['bar']) { |foo, bar| [foo, bar] }).to eql(some[['foo', 'bar']])
+      end
+
+      it 'returns none if argument is none' do
+        expect(some['foo'].and(none) { |foo, bar| fail }).to eql(none)
+      end
+
+      it 'returns a tuple if no block given' do
+        expect(some['foo'].and(some['bar'])).to eql(some[['foo', 'bar']])
+        expect(some['foo'].and(none)).to eql(none)
+      end
+    end
   end
 
   describe maybe::None do
@@ -394,6 +409,14 @@ RSpec.describe(Dry::Monads::Maybe) do
     describe '#flatten' do
       it 'always return None' do
         expect(none.flatten).to eql(none)
+      end
+    end
+
+    describe '#and' do
+      it 'always return None' do
+        expect(none.and(some['foo']) { fail }).to eql(none)
+        expect(none.and(some['foo'])).to eql(none)
+        expect(none.and(none)).to eql(none)
       end
     end
   end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -290,6 +290,22 @@ RSpec.describe(Dry::Monads::Result) do
         expect(success[failure['foo']].flatten).to eql(failure['foo'])
       end
     end
+
+    describe '#and' do
+      it 'joins two success values with a block' do
+        expect(success['foo'].and(success['bar']) { |foo, bar| [foo, bar] }).
+          to eql(success[['foo', 'bar']])
+      end
+
+      it 'returns failure if argument is failure' do
+        expect(success['foo'].and(failure[123]) { |foo, bar| fail }).to eql(failure[123])
+      end
+
+      it 'returns a tuple if no block given' do
+        expect(success['foo'].and(success['bar'])).to eql(success[['foo', 'bar']])
+        expect(some['foo'].and(failure[123])).to eql(failure[123])
+      end
+    end
   end
 
   describe result::Failure do
@@ -480,6 +496,14 @@ RSpec.describe(Dry::Monads::Result) do
     describe '#flatten' do
       it 'always return itself' do
         expect(failure['foo'].flatten).to eql(failure['foo'])
+      end
+    end
+
+    describe '#and' do
+      it 'always return itself' do
+        expect(failure[123].and(success['foo']) { fail }).to eql(failure[123])
+        expect(failure[123].and(success['foo'])).to eql(failure[123])
+        expect(failure[123].and(failure['foo'])).to eql(failure[123])
       end
     end
   end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -280,6 +280,16 @@ RSpec.describe(Dry::Monads::Result) do
         expect(success['foo'].discard).to eql(success[unit])
       end
     end
+
+    describe '#flatten' do
+      it 'removes one level of monad' do
+        expect(success[success['foo']].flatten).to eql(success['foo'])
+      end
+
+      it 'returns Failure for Success(Failure(_))' do
+        expect(success[failure['foo']].flatten).to eql(failure['foo'])
+      end
+    end
   end
 
   describe result::Failure do
@@ -464,6 +474,12 @@ RSpec.describe(Dry::Monads::Result) do
       it 'returns self back' do
         m = failure[1]
         expect(m.discard).to be m
+      end
+    end
+
+    describe '#flatten' do
+      it 'always return itself' do
+        expect(failure['foo'].flatten).to eql(failure['foo'])
       end
     end
   end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -228,16 +228,6 @@ RSpec.describe(Dry::Monads::Result) do
 
           expect(expr_result).to be true
         end
-
-        example 'keywords from value takes precedence' do
-          expr_result = subject.bind(foo: 'bar', bar: 'bar') do |foo:, bar: |
-            expect(foo).to eql('foo')
-            expect(bar).to eql('bar')
-            true
-          end
-
-          expect(expr_result).to be true
-        end
       end
     end
 


### PR DESCRIPTION
These can be handy when dealing with multiple values at once

`#flatten`

Removes one level of monadic structure. Essentially, it's `bind(&:itself)`

```ruby
include Dry::Monads::Result::Mixin

Success(Success(5)).flatten # => Success(5)
Success(Failure(:not_a_number)).flatten # => Failure(:not_a_number)
Failure(:not_a_number).flatten # => Failure(:not_a_number)
```

`#and`

Combines two monadic values with an optional block

```ruby
include Dry::Monads::Result::Mixin

Success(3).and(Success(5)) # => Success([3, 5])
Success(3).and(Failure(:not_a_number)) # => Failure(:not_a_number)
Failure(:not_a_number).and(Success(5)) # => Failure(:not_a_number)
# blocks are supported!
Success(3).and(Success(5)) { |a, b| a + b } # => Success(8)
```
