### PR TITLE
Implement List#collect via monadic primitives

### DIFF
--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -326,18 +326,11 @@ module Dry
       #   # => [10, 6]
       #
       # @return [List]
-      def collect
-        if block_given?
-          collected = value.each_with_object([]) do |x, ys|
-            y = yield(x)
-            ys << y.value! if y.some?
-          end
+      def collect(&block)
+        bind do |e|
+          m = block.nil? ? e : block.call(e)
 
-          List.new(collected)
-        else
-          Enumerator.new do |g|
-            value.each { |x| g << x.value! if x.some? }
-          end
+          m.fmap { |v| [v] }.value_or([])
         end
       end
 

--- a/spec/unit/list_spec.rb
+++ b/spec/unit/list_spec.rb
@@ -363,11 +363,11 @@ RSpec.describe(Dry::Monads::List) do
 
   describe '#collect' do
     it 'gathers Somes' do
-      expect(list[some[1], none, some[3]].collect(&:itself)).to eql(list[1, 3])
+      expect(list[some[1], none, some[3]].collect).to eql(list[1, 3])
     end
 
-    it 'returns enumerator' do
-      expect(list[some[1], none, some[3]].collect.map { |x| x * 2 }).to eql([2, 6])
+    it 'allows a block' do
+      expect(list[1, 2, 3].collect { |i| i < 3 ? some[i] : none }).to eql(list[1, 2])
     end
   end
 end


### PR DESCRIPTION
This PR updates the implementation of `List#collect` to use the monadic functions`bind`, `fmap` and `value_or`.

It also updates the method to always return a `List`. It feels inconsistent to me to return a `List` monad if no block is provided but to return a primitive array if a block is provided.

Let me know what you think.