### PR TITLE
Add call aliases for new

### DIFF
--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -124,7 +124,7 @@ module Dry
         include RightBiased::Left
         include Dry::Equalizer(:failure)
 
-        singleton_class.alias_method(:call, :new)
+        singleton_class.send(:alias_method, :call, :new)
 
         # Returns a constructor proc
         #

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -124,6 +124,8 @@ module Dry
         include RightBiased::Left
         include Dry::Equalizer(:failure)
 
+        singleton_class.alias_method(:call, :new)
+
         # Returns a constructor proc
         #
         # @return [Proc]

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -21,6 +21,7 @@ module Dry
           def m.to_proc
             @to_proc ||= method(:new).to_proc
           end
+          m.singleton_class.alias_method(:call, :new)
         end
 
         # Unwraps the underlying value

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -21,7 +21,7 @@ module Dry
           def m.to_proc
             @to_proc ||= method(:new).to_proc
           end
-          m.singleton_class.alias_method(:call, :new)
+          m.singleton_class.send(:alias_method, :call, :new)
         end
 
         # Unwraps the underlying value

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -168,7 +168,7 @@ module Dry
         include Dry::Equalizer(:exception)
         include RightBiased::Left
 
-        singleton_class.alias_method(:call, :new)
+        singleton_class.send(:alias_method, :call, :new)
 
         # @param exception [Exception]
         def initialize(exception)

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -168,6 +168,8 @@ module Dry
         include Dry::Equalizer(:exception)
         include RightBiased::Left
 
+        singleton_class.alias_method(:call, :new)
+
         # @param exception [Exception]
         def initialize(exception)
           @exception = exception

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
     end
 
+    describe '.call' do
+      it 'is an alias for new' do
+        expect(maybe::Some.('foo')).to eql(subject)
+
+        if RUBY_VERSION > '2.6'
+          expect((-> x { x.downcase } >> maybe::Some).('FOO')).to eql(subject)
+        end
+      end
+    end
+
     describe '#bind' do
       it 'accepts a proc and does not lift the result' do
         expect(subject.bind(upcase)).to eql('FOO')

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -301,6 +301,16 @@ RSpec.describe(Dry::Monads::Result) do
   describe result::Failure do
     subject { result::Failure.new('bar') }
 
+    describe '.call' do
+      it 'is an alias for new' do
+        expect(result::Failure.('bar')).to eql(subject)
+
+        if RUBY_VERSION > '2.6'
+          expect((-> x { x.downcase } >> result::Failure).('BAR')).to eql(subject)
+        end
+      end
+    end
+
     it_behaves_like 'a monad'
 
     it { is_expected.not_to be_success }

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -199,6 +199,16 @@ RSpec.describe(Dry::Monads::Try) do
     let(:upcase_value) { described_class.new([ZeroDivisionError], 'FOO') }
     let(:upcase_error) { try::Error.new(division_error) }
 
+    describe '.call' do
+      it 'is an alias for new' do
+        expect(try::Error.(division_error)).to eql(subject)
+
+        if RUBY_VERSION > '2.6'
+          expect((-> x { x } >> try::Error).(division_error)).to eql(subject)
+        end
+      end
+    end
+
     it { is_expected.not_to be_value }
     it { is_expected.to be_error }
     it { is_expected.not_to be_success }


### PR DESCRIPTION
Now in ruby 2.6+ you can compose procs with monad constructors:

```ruby
pipe = -> x { x * 2 } >> Some
pipe.(2) # => Some(4)
```