### PR TITLE
Add Dry::Monads.[] for building a module with cherry-picked monads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,30 @@
   None().and(Some(5)) # => None()
   ```
 
+* Concise imports with `Dry::Monads.[]`. You're no longer required to require all desired monads and include them one-by-one, the `[]` method handles it for you (flash-gordon)
+
+  ```ruby
+  require 'dry/monads'
+
+  class CreateUser
+    include Dry::Monads[:result, :do]
+
+    def initialize(repo, send_email)
+      @repo = repo
+      @send_email = send_email
+    end
+
+    def call(name)
+      if @repo.user_exist?(name)
+        Failure(:user_exists)
+      else
+        user = yield @repo.add_user(name)
+        yield @send_email.(user)
+        Success(user)
+      end
+    end
+  end
+  ```
 * `Task.failed` is a counterpart of `Task.pure`, accepts an exception and returns a failed task immediately (flash-gordon)
 
 [Compare v1.1.0...master](https://github.com/dry-rb/dry-monads/compare/v1.1.0...master)

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,13 +1,52 @@
+require 'dry/monads/registry'
+
 module Dry
   # Common, idiomatic monads for Ruby
   #
   # @api public
   module Monads
     def self.included(base)
-      if const_defined?(:CONSTRUCTORS)
-        base.include(*CONSTRUCTORS)
+      if @registry.frozen?
+        base.include(*monad_constructors)
       else
         raise "Load all monads first with require 'dry/monads/all'"
+      end
+    end
+
+    # Build a module with cherry-picked monads.
+    # It saves a bit of typing when you add multiple
+    # monads to one class. Not loaded monads get loaded automatically.
+    #
+    # @example
+    #   require 'dry/monads'
+    #
+    #   class CreateUser
+    #     include Dry::Monads[:result, :do]
+    #
+    #     def initialize(repo, send_email)
+    #       @repo = repo
+    #       @send_email = send_email
+    #     end
+    #
+    #     def call(name)
+    #       if @repo.user_exist?(name)
+    #         Failure(:user_exists)
+    #       else
+    #         user = yield @repo.add_user(name)
+    #         yield @send_email.(user)
+    #         Success(user)
+    #       end
+    #     end
+    #   end
+    #
+    # @param [Array<Symbol>] monads
+    # @return [Module]
+    # @api public
+    def self.[](*monads)
+      @mixins.fetch_or_store(monads.sort.hash) do
+        monads.each { |m| load_monad(m) }
+        mixins = monads.map { |m| @registry.fetch(m) }
+        Module.new { include(*mixins) }.freeze
       end
     end
   end

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -6,8 +6,8 @@ module Dry
   # @api public
   module Monads
     def self.included(base)
-      if @registry.frozen?
-        base.include(*monad_constructors)
+      if all_loaded?
+        base.include(*constructors)
       else
         raise "Load all monads first with require 'dry/monads/all'"
       end
@@ -43,9 +43,10 @@ module Dry
     # @return [Module]
     # @api public
     def self.[](*monads)
-      @mixins.fetch_or_store(monads.sort.hash) do
+      monads.sort!
+      @mixins.fetch_or_store(monads.hash) do
         monads.each { |m| load_monad(m) }
-        mixins = monads.map { |m| @registry.fetch(m) }
+        mixins = monads.map { |m| registry.fetch(m) }
         Module.new { include(*mixins) }.freeze
       end
     end

--- a/lib/dry/monads/all.rb
+++ b/lib/dry/monads/all.rb
@@ -4,7 +4,6 @@ require 'dry/monads/registry'
 module Dry
   module Monads
     known_monads.each { |m| load_monad(m) }
-    @registry.freeze
-    extend(*monad_constructors)
+    extend(*constructors)
   end
 end

--- a/lib/dry/monads/all.rb
+++ b/lib/dry/monads/all.rb
@@ -1,26 +1,10 @@
 require 'dry/monads'
-require 'dry/monads/do'
-require 'dry/monads/lazy'
-require 'dry/monads/list'
-require 'dry/monads/maybe'
-require 'dry/monads/result'
-require 'dry/monads/result/fixed'
-require 'dry/monads/task'
-require 'dry/monads/try'
-require 'dry/monads/validated'
+require 'dry/monads/registry'
 
 module Dry
   module Monads
-    # List of monad constructors
-    CONSTRUCTORS = [
-      Lazy::Mixin::Constructors,
-      Maybe::Mixin::Constructors,
-      Result::Mixin::Constructors,
-      Task::Mixin::Constructors,
-      Try::Mixin::Constructors,
-      Validated::Mixin::Constructors,
-    ].freeze
-
-    extend(*CONSTRUCTORS)
+    known_monads.each { |m| load_monad(m) }
+    @registry.freeze
+    extend(*monad_constructors)
   end
 end

--- a/lib/dry/monads/do/all.rb
+++ b/lib/dry/monads/do/all.rb
@@ -77,6 +77,11 @@ module Dry
 
                 base.prepend(wrappers[base])
               end
+
+              def included(base)
+                super
+                Dry::Monads::Do::All.included(base)
+              end
             end
           end
 
@@ -101,5 +106,8 @@ module Dry
         end
       end
     end
+
+    require 'dry/monads/registry'
+    register_mixin(:do, Do::All)
   end
 end

--- a/lib/dry/monads/lazy.rb
+++ b/lib/dry/monads/lazy.rb
@@ -78,6 +78,7 @@ module Dry
       end
     end
 
-    extend Lazy::Mixin::Constructors
+    require 'dry/monads/registry'
+    register_mixin(:lazy, Lazy::Mixin)
   end
 end

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -409,6 +409,9 @@ module Dry
         end
       end
     end
+
+    require 'dry/monads/registry'
+    register_mixin(:list, List::Mixin)
   end
 end
 

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -296,5 +296,8 @@ module Dry
         end
       end
     end
+
+    require 'dry/monads/registry'
+    register_mixin(:maybe, Maybe::Mixin)
   end
 end

--- a/lib/dry/monads/registry.rb
+++ b/lib/dry/monads/registry.rb
@@ -1,0 +1,64 @@
+require 'concurrent/map'
+
+module Dry
+  # Common, idiomatic monads for Ruby
+  #
+  # @api private
+  module Monads
+    @registry = {}
+    @paths = {
+      do: 'dry/monads/do/all',
+      lazy: 'dry/monads/lazy',
+      list: 'dry/monads/list',
+      maybe: 'dry/monads/maybe',
+      task: 'dry/monads/task',
+      try: 'dry/monads/try',
+      validated: 'dry/monads/validated',
+      result: [
+        'dry/monads/result',
+        'dry/monads/result/fixed'
+      ]
+    }.freeze
+    @mixins = Concurrent::Map.new
+
+    class << self
+      private
+
+      # @private
+      def register_mixin(name, mod)
+        if @registry.key?(name)
+          raise ArgumentError, "#{ name.inspect } is already registered"
+        end
+        @registry[name] = mod
+      end
+
+      # @private
+      def known_monads
+        @paths.keys
+      end
+
+      # @private
+      def load_monad(name)
+        path = @paths.fetch(name) {
+          raise ArgumentError, "#{ name.inspect } is not a known monad"
+        }
+        Array(path).each { |p| require p }
+      end
+
+      # @private
+      def unload_monad(name)
+        if @registry.key?(name.to_sym)
+          @registry = @registry.dup
+          @registry.delete(name.to_sym)
+        end
+      end
+
+      # @private
+      def monad_constructors
+        @registry.values.map { |m|
+          m::Constructors if m.const_defined?(:Constructors)
+        }.compact
+      end
+    end
+  end
+end

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -367,5 +367,8 @@ module Dry
         end
       end
     end
+
+    require 'dry/monads/registry'
+    register_mixin(:result, Result::Mixin)
   end
 end

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -307,6 +307,7 @@ module Dry
       end
     end
 
-    extend Task::Mixin::Constructors
+    require 'dry/monads/registry'
+    register_mixin(:task, Task::Mixin)
   end
 end

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -275,6 +275,7 @@ module Dry
       end
     end
 
-    extend Try::Mixin::Constructors
+    require 'dry/monads/registry'
+    register_mixin(:try, Try::Mixin)
   end
 end

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -296,5 +296,8 @@ module Dry
         end
       end
     end
+
+    require 'dry/monads/registry'
+    register_mixin(:validated, Validated::Mixin)
   end
 end

--- a/spec/integration/all_monads_inclusion_spec.rb
+++ b/spec/integration/all_monads_inclusion_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Dry::Monads module mixin" do
   it "raises an error when all monads are not loaded" do
-    Dry::Monads.send :remove_const, :CONSTRUCTORS
+    Dry::Monads.instance_exec { @registry = @registry.dup }
 
     expect {
       class Test::MyClass
@@ -8,7 +8,7 @@ RSpec.describe "Dry::Monads module mixin" do
       end
     }.to raise_error RuntimeError, %r{Load all monads first}
 
-    re_require "all"
+    re_require
   end
 
   it "raises no error when all monads are loaded" do

--- a/spec/integration/all_monads_inclusion_spec.rb
+++ b/spec/integration/all_monads_inclusion_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Dry::Monads module mixin" do
   it "raises an error when all monads are not loaded" do
-    Dry::Monads.instance_exec { @registry = @registry.dup }
+    Dry::Monads.unload_monad(:maybe)
 
     expect {
       class Test::MyClass
@@ -8,7 +8,7 @@ RSpec.describe "Dry::Monads module mixin" do
       end
     }.to raise_error RuntimeError, %r{Load all monads first}
 
-    re_require
+    re_require 'maybe'
   end
 
   it "raises no error when all monads are loaded" do

--- a/spec/integration/either_spec.rb
+++ b/spec/integration/either_spec.rb
@@ -1,8 +1,10 @@
-require 'dry/monads/either'
-
 RSpec.describe 'Dry::Monads::Either', :suppress_deprecations do
-  suppress_warnings do
-    include Dry::Monads::Either::Mixin
+  before { require 'dry/monads/either' }
+
+  before do
+    suppress_warnings do
+      self.class.include Dry::Monads::Either::Mixin
+    end
   end
 
   specify do

--- a/spec/integration/monads_spec.rb
+++ b/spec/integration/monads_spec.rb
@@ -157,4 +157,46 @@ RSpec.describe(Dry::Monads) do
       end
     end
   end
+
+  describe '[]' do
+    it 'creates a module with cherry-picked monad' do
+      maybe_only = Class.new { include Dry::Monads[:maybe] }
+
+      expect(maybe_only.new.Some(1)).to eql(m.Some(1))
+    end
+
+    it 'works with multiple monads' do
+      ctx = Class.new do
+        include Dry::Monads[:maybe, :result]
+
+        def call
+          [Some(:foo), Success(:bar), Failure(:baz)]
+        end
+      end
+
+      expect(ctx.new.()).to eql([m.Some(:foo), m.Success(:bar), m.Failure(:baz)])
+    end
+
+    it 'caches modules' do
+      expect(Dry::Monads[:maybe, :result]).to be(Dry::Monads[:result, :maybe])
+    end
+
+    it 'freezes mixins' do
+      expect(Dry::Monads[:maybe]).to be_frozen
+    end
+
+    it 'workds with do' do
+      ctx = Class.new do
+        include Dry::Monads[:maybe, :do]
+
+        def call(x, y)
+          a = yield x
+          b = yield y
+          Some(a + b)
+        end
+      end
+
+      expect(ctx.new.(m.Some(1), m.Some(2))).to eql(m.Some(3))
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ end
 
 module TestHelpers
   def re_require(*paths)
-    paths.each { |p| Dry::Monads.send(:unload_monad, p) }
+    paths.each { |p| Dry::Monads.unload_monad(p) }
     all_paths = paths + %w(all)
 
     $LOADED_FEATURES.delete_if { |feature|
@@ -61,6 +61,14 @@ end
 module Test
   def self.remove_constants
     constants.each(&method(:remove_const))
+  end
+end
+
+module Dry::Monads
+  def self.unload_monad(name)
+    if registry.key?(name.to_sym)
+      self.registry = registry.reject { |k, _| k == name.to_sym }
+    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,12 +42,15 @@ end
 
 module TestHelpers
   def re_require(*paths)
+    paths.each { |p| Dry::Monads.send(:unload_monad, p) }
+    all_paths = paths + %w(all)
+
     $LOADED_FEATURES.delete_if { |feature|
-      paths.any? { |path| feature.include?("dry/monads/#{path}.rb") }
+      all_paths.any? { |path| feature.include?("dry/monads/#{path}.rb") }
     }
 
     suppress_warnings do
-      paths.each do |path|
+      all_paths.each do |path|
         require "dry/monads/#{path}"
       end
     end


### PR DESCRIPTION
Now it's no longer required to enumerate monads in two places (`require` + `include`). I finally managed to add this:

```ruby
require 'dry/monads'

class CreateUser
  include Dry::Monads[:result, :do]

  def initialize(repo, send_email)
    @repo = repo
    @send_email = send_email
  end

  def call(name)
    if @repo.user_exist?(name)
      Failure(:user_exists)
    else
      user = yield @repo.add_user(name)
      yield @send_email.(user)
      Success(user)
    end
  end
end
```