### PR TITLE
Extension to serialize a Maybe into a string

### DIFF
--- a/lib/dry/monads/extensions/string_serialization/maybe.rb
+++ b/lib/dry/monads/extensions/string_serialization/maybe.rb
@@ -1,0 +1,30 @@
+require 'dry/core/extensions'
+
+module Dry
+  module Monads
+    class Maybe
+      extend Dry::Core::Extensions
+
+      register_extension(:string_serialization) do
+        class Some
+          # Serializes inner value to a string and returns the result.
+          #
+          # @return [String] the result of calling `#to_str` in the inner value
+          # @raise [NoMethodError] when inner value does not respond to `#to_str`
+          def to_str!
+            fmap(&:to_str).value!
+          end
+        end
+
+        class None
+          # Returns empty string.
+          #
+          # @return [String]
+          def to_str!
+            ''
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/string_serialization/maybe_spec.rb
+++ b/spec/extensions/string_serialization/maybe_spec.rb
@@ -1,0 +1,37 @@
+require 'dry/monads/extensions/string_serialization/maybe'
+
+RSpec.describe(Dry::Monads::Maybe) do
+  maybe = described_class
+
+  before { maybe.load_extensions(:string_serialization) }
+
+  describe maybe::Some do
+    describe '#to_str!' do
+      context 'when internal value responds to #to_str' do
+        it 'returns unwrapped result' do
+          instance = described_class.new('foo')
+
+          expect(instance.to_str!).to eq('foo')
+        end
+      end
+
+      context 'when internal value does not respond to #to_str' do
+        it 'raises NoMethodError' do
+          instance = described_class.new(1)
+
+          expect { instance.to_str! }.to raise_error(NoMethodError)
+        end
+      end
+    end
+  end
+
+  describe maybe::None do
+    describe '#to_str!' do
+      it 'returns the empty string' do
+        instance = described_class.new
+        
+        expect(instance.to_str!).to eq('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
It allows to easily use Maybe instances in template engines:

```ruby
require 'dry/monads/extensions/string_serialization/maybe'

Dry::Monads::Maybe.load_extensions(:string_serialization)

Dry::Monads::Maybe::Some.new('foo').to_str!
\# => "foo"
Dry::Monads::Maybe::None.new.to_str!
\# => ""
Dry::Monads::Maybe::Some.new(1).to_str!
\# => NoMethodError
```

Serialization method is called `#to_str!` because `#to_str` is the ruby
convention for something that can act as a string for all purposes, in
constrast of `#to_s` which is used for something that simply has a
string representation. The bang (`!`) is added because the method is not
safe: if the inner value does not respond to `#to_str` then a
`NoMethodError` is raised.

Resources:

- [Original
discussion](https://discourse.dry-rb.org/t/string-representation-for-maybe-monad/696)