### PR TITLE
Introduce Result#either method

### DIFF
--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'dry/equalizer'
 
 require 'dry/monads/undefined'
@@ -101,6 +102,18 @@ module Dry
         # @return [Result::Success]
         def fmap(*args, &block)
           Success.new(bind(*args, &block))
+        end
+
+        # Returns result of applying first function to the internal value.
+        #
+        # @example
+        #   Dry::Monads.Success(1).either(-> x { x + 1 }, -> x { x + 2 }) # => 2
+        #
+        # @param f [#call] Function to apply
+        # @param g [#call] Ignored
+        # @return [Any] Return value of `f`
+        def either(f, _g)
+          f.(success)
         end
 
         # @return [String]
@@ -224,6 +237,18 @@ module Dry
         # @return [Boolean]
         def ===(other)
           Failure === other && failure === other.failure
+        end
+
+        # Returns result of applying second function to the internal value.
+        #
+        # @example
+        #   Dry::Monads.Failure(1).either(-> x { x + 1 }, -> x { x + 2 }) # => 3
+        #
+        # @param f [#call] Ignored
+        # @param g [#call] Function to call
+        # @return [Any] Return value of `g`
+        def either(_f, g)
+          g.(failure)
         end
       end
 

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'dry/equalizer'
 
 require 'dry/monads/undefined'

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -296,6 +296,12 @@ RSpec.describe(Dry::Monads::Result) do
         expect(some['foo'].and(failure[123])).to eql(failure[123])
       end
     end
+
+    describe '#either' do
+      it 'returns first function applied to the value' do
+        expect(success['foo'].either(-> x { x + 'foo' }, -> x { x + 'bar' })).to eq('foofoo')
+      end
+    end
   end
 
   describe result::Failure do
@@ -504,6 +510,12 @@ RSpec.describe(Dry::Monads::Result) do
         expect(failure[123].and(success['foo']) { fail }).to eql(failure[123])
         expect(failure[123].and(success['foo'])).to eql(failure[123])
         expect(failure[123].and(failure['foo'])).to eql(failure[123])
+      end
+    end
+
+    describe '#either' do
+      it 'returns second function applied to the value' do
+        expect(failure['bar'].either(-> x { x + 'foo' }, -> x { x + 'bar' })).to eq('barbar')
       end
     end
   end


### PR DESCRIPTION
`Result#either` takes two callable arguments. If the value is a success
passes it as argument to the first function and returns the result. If it
is a failure does the same with the second function.

```ruby
Dry::Monads.Success(1).either(-> x { x + 1 }, -> x { x + 2 }) # => 2
Dry::Monads.Failure(1).either(-> x { x + 1 }, -> x { x + 2 }) # => 3
```