### PR TITLE
Add to result method to maybe

### DIFF
--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -319,6 +319,20 @@ module Dry
       Result::Fixed[error, **options]
     end
 
+    class Maybe
+      class Some < Maybe
+        def to_result(_fail)
+          Result::Success.new(@value)
+        end
+      end
+
+      class None < Maybe
+        def to_result(fail)
+          Result::Failure.new(fail)
+        end
+      end
+    end
+
     class Task
       # Converts to Result. Blocks the current thread if required.
       #

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -2,6 +2,9 @@ RSpec.describe(Dry::Monads::Maybe) do
   maybe = described_class
   some = maybe::Some.method(:new)
   none = maybe::None.new
+  result = Dry::Monads::Result
+  success = result::Success.method(:new)
+  failure = result::Failure.method(:new)
   unit = Dry::Monads::Unit
 
   let(:upcase) { :upcase.to_proc }
@@ -170,6 +173,12 @@ RSpec.describe(Dry::Monads::Maybe) do
       let(:subject) { some['foo'].to_maybe }
 
       it { is_expected.to eql some['foo'] }
+    end
+
+    describe '#to_result' do
+      it 'transforms self to Result::Success' do
+        expect(subject.to_result('baz')).to eql(success['foo'])
+      end
     end
 
     describe '#tee' do
@@ -363,6 +372,12 @@ RSpec.describe(Dry::Monads::Maybe) do
       let(:subject) { none.to_maybe }
 
       it { is_expected.to eql maybe::None.new }
+    end
+
+    describe '#to_result' do
+      it 'transforms self to Result::Failure' do
+        expect(subject.to_result('bar')).to eql(failure['bar'])
+      end
     end
 
     describe '#tee' do


### PR DESCRIPTION
I ran into a situation where I wanted to transform my Maybe to a Result. Something like Scala's toRight/toLeft. https://www.scala-lang.org/api/2.12.8/scala/Option.html#toRight[X](left:=%3EX):Either[X,A]

I felt for this library, a Maybe#toResult would be a bit more practical where 
 Some(x) => Success(x)
 None => Failure([some_default_case])

Here's an implementation, let me know what you think.