### PR TITLE
 Add Do::Mixin

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -1,4 +1,5 @@
 require 'dry/monads/list'
+require 'dry/monads/do/mixin'
 
 module Dry
   module Monads
@@ -6,9 +7,11 @@ module Dry
     #
     # @see Do.for
     module Do
-      # @private
+      extend Mixin
+
+      # @api private
       class Halt < StandardError
-        # @private
+        # @api private
         attr_reader :result
 
         def initialize(result)
@@ -18,134 +21,117 @@ module Dry
         end
       end
 
-      # Generates a module that passes a block to methods
-      # that either unwraps a single-valued monadic value or halts
-      # the execution.
-      #
-      # @example A complete example
-      #
-      #   class CreateUser
-      #     include Dry::Monads::Result::Mixin
-      #     include Dry::Monads::Try::Mixin
-      #     include Dry::Monads::Do.for(:call)
-      #
-      #     attr_reader :user_repo
-      #
-      #     def initialize(:user_repo)
-      #       @user_repo = user_repo
-      #     end
-      #
-      #     def call(params)
-      #       json = yield parse_json(params)
-      #       hash = yield validate(json)
-      #
-      #       user_repo.transaction do
-      #         user = yield create_user(hash[:user])
-      #         yield create_profile(user, hash[:profile])
-      #       end
-      #
-      #       Success(user)
-      #     end
-      #
-      #     private
-      #
-      #     def parse_json(params)
-      #       Try(JSON::ParserError) {
-      #         JSON.parse(params)
-      #       }.to_result
-      #     end
-      #
-      #     def validate(json)
-      #       UserSchema.(json).to_monad
-      #     end
-      #
-      #     def create_user(user_data)
-      #       Try(Sequel::Error) {
-      #         user_repo.create(user_data)
-      #       }.to_result
-      #     end
-      #
-      #     def create_profile(user, profile_data)
-      #       Try(Sequel::Error) {
-      #         user_repo.create_profile(user, profile_data)
-      #       }.to_result
-      #     end
-      #   end
-      #
-      # @param [Array<Symbol>] methods
-      # @return [Module]
-      def self.for(*methods)
-        mod = Module.new do
-          methods.each { |method_name| Do.wrap_method(self, method_name) }
-        end
-
-        Module.new do
-          singleton_class.send(:define_method, :included) do |base|
-            base.prepend(mod)
+      class << self
+        # Generates a module that passes a block to methods
+        # that either unwraps a single-valued monadic value or halts
+        # the execution.
+        #
+        # @example A complete example
+        #
+        #   class CreateUser
+        #     include Dry::Monads::Result::Mixin
+        #     include Dry::Monads::Try::Mixin
+        #     include Dry::Monads::Do.for(:call)
+        #
+        #     attr_reader :user_repo
+        #
+        #     def initialize(:user_repo)
+        #       @user_repo = user_repo
+        #     end
+        #
+        #     def call(params)
+        #       json = yield parse_json(params)
+        #       hash = yield validate(json)
+        #
+        #       user_repo.transaction do
+        #         user = yield create_user(hash[:user])
+        #         yield create_profile(user, hash[:profile])
+        #       end
+        #
+        #       Success(user)
+        #     end
+        #
+        #     private
+        #
+        #     def parse_json(params)
+        #       Try(JSON::ParserError) {
+        #         JSON.parse(params)
+        #       }.to_result
+        #     end
+        #
+        #     def validate(json)
+        #       UserSchema.(json).to_monad
+        #     end
+        #
+        #     def create_user(user_data)
+        #       Try(Sequel::Error) {
+        #         user_repo.create(user_data)
+        #       }.to_result
+        #     end
+        #
+        #     def create_profile(user, profile_data)
+        #       Try(Sequel::Error) {
+        #         user_repo.create_profile(user, profile_data)
+        #       }.to_result
+        #     end
+        #   end
+        #
+        # @param [Array<Symbol>] methods
+        # @return [Module]
+        def for(*methods)
+          mod = ::Module.new do
+            methods.each { |method_name| Do.wrap_method(self, method_name) }
           end
-        end
-      end
 
-      # @api private
-      def self.included(base)
-        super
-
-        # Actually mixes in Do::All
-        require 'dry/monads/do/all'
-        base.include All
-      end
-
-      protected
-
-      # @private
-      def self.halt(result)
-        raise Halt.new(result)
-      end
-
-      # @private
-      def self.coerce_to_monad(monads)
-        return monads if monads.size != 1
-
-        first = monads[0]
-
-        case first
-        when Array
-          [List.coerce(first).traverse]
-        when List
-          [first.traverse]
-        else
-          monads
-        end
-      end
-
-      def self.bind(*monads)
-        monads = Do.coerce_to_monad(monads)
-        unwrapped = monads.map { |result|
-          monad = result.to_monad
-          monad.or { Do.halt(monad) }.value!
-        }
-        monads.size == 1 ? unwrapped[0] : unwrapped
-      end
-
-      def self.wrap
-        yield
-      rescue Halt => e
-        e.result
-      end
-
-      # @private
-      def self.wrap_method(target, method_name)
-        target.module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-          def #{ method_name }(*)
-            if block_given?
-              super
-            else
-              Do.wrap do
-                super { |*monads| Do.bind(*monads) } 
-              end
+          ::Module.new do
+            singleton_class.send(:define_method, :included) do |base|
+              base.prepend(mod)
             end
           end
-        RUBY
+        end
+
+        # @api private
+        def included(base)
+          super
+
+          # Actually mixes in Do::All
+          require 'dry/monads/do/all'
+          base.include All
+        end
+
+        # @api private
+        def wrap_method(target, method_name)
+          target.module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            def #{method_name}(*)
+              if block_given?
+                super
+              else
+                Do.() { super { |*ms| Do.bind(ms) } }
+              end
+            end
+          RUBY
+        end
+
+        # @api private
+        def coerce_to_monad(monads)
+          return monads if monads.size != 1
+
+          first = monads[0]
+
+          case first
+          when ::Array
+            [List.coerce(first).traverse]
+          when List
+            [first.traverse]
+          else
+            monads
+          end
+        end
+
+        # @api private
+        def halt(result)
+          raise Halt.new(result)
+        end
       end
     end
   end

--- a/lib/dry/monads/do/mixin.rb
+++ b/lib/dry/monads/do/mixin.rb
@@ -1,0 +1,56 @@
+module Dry
+  module Monads
+    module Do
+      # Do notation as a mixin.
+      # You can use it in any place in your code, see examples.
+      #
+      # @example class-level mixin
+      #
+      #   class CreateUser
+      #     extend Dry::Monads::Do::Mixin
+      #     extend Dry::Monads[:result]
+      #
+      #     def self.run(params)
+      #       self.call do
+      #         values = bind Validator.validate(params)
+      #         user = bind UserRepository.create(values)
+      #
+      #         Success(user)
+      #       end
+      #     end
+      #   end
+      #
+      # @example using methods defined on Do
+      #
+      #   create_user = proc do |params|
+      #     Do.() do
+      #       values = bind validate(params)
+      #       user = bind user_repo.create(values)
+      #
+      #       Success(user)
+      #     end
+      #   end
+      #
+      # @api public
+      module Mixin
+        # @api public
+        def call
+          yield
+        rescue Halt => e
+          e.result
+        end
+
+        # @api public
+        def bind(monads)
+          monads = Do.coerce_to_monad(Array(monads))
+          unwrapped = monads.map { |result|
+            monad = result.to_monad
+            monad.or { Do.halt(monad) }.value!
+          }
+          monads.size == 1 ? unwrapped[0] : unwrapped
+        end
+      end
+    end
+  end
+end
+

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -422,11 +422,25 @@ RSpec.describe(Dry::Monads::Do) do
     end
   end
 
-  describe '.wrap and .bind' do
+  describe 'Do::Mixin' do
+    include Dry::Monads::Do::Mixin
+
+    let(:block) do
+      lambda do |success|
+        self.() do
+          value_1 = bind(Success(2))
+          value_2 = bind(success ? Success(3) : Failure('oops'))
+          Success(value_1 + value_2)
+        end
+      end
+    end
+
     before do
       klass.class_eval do
+        extend Dry::Monads::Do::Mixin
+
         def test_method(success)
-          Dry::Monads::Do.wrap do
+          Dry::Monads::Do.() do
             value_1 = Dry::Monads::Do.bind(Success(2))
             value_2 = Dry::Monads::Do.bind(success ? Success(3) : Failure('oops'))
             Success(value_1 + value_2)
@@ -437,13 +451,13 @@ RSpec.describe(Dry::Monads::Do) do
 
     context 'successful case' do
       it 'returns the result of a statement' do
-        expect(instance.test_method(true)).to eq Success(5)
+        expect(block.(true)).to eql(Success(5))
       end
     end
 
     context 'first failure' do
       it 'returns failure' do
-        expect(instance.test_method(false)).to eq Failure('oops')
+        expect(block.(false)).to eql(Failure('oops'))
       end
     end
   end


### PR DESCRIPTION
This adds two new ways of using do notation:

1) As a mixin:

```ruby
class CreateUser
  extend Dry::Monads::Do::Mixin
  extend Dry::Monads[:result]

  def self.run(params)
    self.call do
      values = bind Validator.validate(params)
      user = bind UserRepository.create(values)

      Success(user)
    end
  end
end
```

2) Using `Do` methods 

```ruby
create_user = proc do |params|
  Do.() do
    values = bind validate(params)
    user = bind user_repo.create(values)

    Success(user)
  end
end
```
