### PR TITLE
Do::Halt - use Exception instead of StandardError

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -10,7 +10,7 @@ module Dry
       extend Mixin
 
       # @api private
-      class Halt < StandardError
+      class Halt < Exception
         # @api private
         attr_reader :result
 

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe(Dry::Monads::Do) do
 
           def transaction
             yield
-          rescue => e
+          rescue Exception => e
             @rolled_back = true
             raise e
           end
@@ -116,6 +116,27 @@ RSpec.describe(Dry::Monads::Do) do
       it 'halts the executing with an exception' do
         expect(instance.call).to eql(Failure(:no_two))
         expect(instance.rolled_back).to be(true)
+      end
+    end
+
+    context 'with rescue block in method' do
+      before do
+        klass.class_eval do
+          def call(m1)
+            yield m1
+            raise "oops"
+          rescue => e
+            Failure("handled exception: #{e}")
+          end
+        end
+      end
+
+      it 'catches standard exception' do
+        expect(instance.call(Success(1))).to eql(Failure("handled exception: oops"))
+      end
+
+      it 'does not catch Halt exception' do
+        expect(instance.call(Failure(5))).to eql(Failure(5))
       end
     end
   end


### PR DESCRIPTION
`Do::Halt` is a `StandardError`. Because of that rescue block can unexpectedly catch it in a wrapped method. This problem has been reported at https://github.com/dry-rb/dry-monads/issues/72

If `Do::Halt` was a direct `Exception` derivative it would be nearly invisible to end-user.

Both ActiveRecord and Sequel catch `Exception`. While this indeed is a breaking change it shouldn't affect majority of users.

In [Discourse discussion](https://discourse.dry-rb.org/t/dry-monads-do-halt-use-exception-instead-of-standarderror/810) we agreed that this breaking change will be included in some future major release.