### PR TITLE
Add {Success,Failure,Some}.[]

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -89,6 +89,20 @@ module Dry
         include Dry::Equalizer(:value!)
         include RightBiased::Right
 
+        # Shortcut for Some([...])
+        #
+        #  @example
+        #    include Dry::Monads[:maybe]
+        #
+        #    def call
+        #      Some[200, {}, ['ok']] # => Some([200, {}, ['ok']])
+        #    end
+        #
+        # @api public
+        def self.[](*value)
+          new(value)
+        end
+
         def initialize(value = Undefined)
           raise ArgumentError, 'nil cannot be some' if value.nil?
           @value = Undefined.default(value, Unit)

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -66,6 +66,20 @@ module Dry
         include RightBiased::Right
         include Dry::Equalizer(:value!)
 
+        # Shortcut for Success([...])
+        #
+        #  @example
+        #    include Dry::Monads[:result]
+        #
+        #    def call
+        #      Success[200, {}, ['ok']] # => Success([200, {}, ['ok']])
+        #    end
+        #
+        # @api public
+        def self.[](*value)
+          new(value)
+        end
+
         alias_method :success, :value!
 
         # @param value [Object] a value of a successful operation
@@ -137,6 +151,20 @@ module Dry
         include Dry::Equalizer(:failure)
 
         singleton_class.send(:alias_method, :call, :new)
+
+        # Shortcut for Failure([...])
+        #
+        #  @example
+        #    include Dry::Monads[:result]
+        #
+        #    def call
+        #      Failure[:error, :not_found] # => Failure([:error, :not_found])
+        #    end
+        #
+        # @api public
+        def self.[](*value)
+          new(value, RightBiased::Left.trace_caller)
+        end
 
         # Returns a constructor proc
         #

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
     end
 
+    describe '.[]' do
+      it 'builds a Some with an array' do
+        expect(described_class[1, 2]).to eql(some[[1, 2]])
+      end
+    end
+
     describe '#bind' do
       it 'accepts a proc and does not lift the result' do
         expect(subject.bind(upcase)).to eql('FOO')

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe(Dry::Monads::Result) do
       expect(subject.inspect).to eql('Success("foo")')
     end
 
+    describe '.[]' do
+      it 'builds a Success with an array' do
+        expect(described_class[:found, 1]).to eql(success[[:found, 1]])
+      end
+    end
+
     describe '#bind' do
       it 'accepts a proc and does not lift the result' do
         expect(subject.bind(upcase)).to eql('FOO')
@@ -332,6 +338,12 @@ RSpec.describe(Dry::Monads::Result) do
 
     it 'has custom inspection' do
       expect(subject.inspect).to eql('Failure("bar")')
+    end
+
+    describe '.[]' do
+      it 'builds a Failure with an array' do
+        expect(described_class[:not_found, :but_tried]).to eql(failure[[:not_found, :but_tried]])
+      end
     end
 
     describe '#bind' do


### PR DESCRIPTION
These methods wrapped passed values with an array. It is useful when you want to pass a tuple within a result or maybe value.

```ruby
# works like
Success[1, 2] # => Success([1, 2])
```