### PR TITLE
Add Maybe::Hash.{all,filter}

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -247,6 +247,47 @@ module Dry
 
         include Constructors
       end
+
+      module Hash
+        # Traverses a hash with maybe values. If any value is None then None is returned
+        #
+        # @example
+        #   Maybe::Hash.all(foo: Some(1), bar: Some(2)) # => Some(foo: 1, bar: 2)
+        #   Maybe::Hash.all(foo: Some(1), bar: None())  # => None()
+        #   Maybe::Hash.all(foo: None(), bar: Some(2))  # => None()
+        #
+        # @param hash [::Hash<Object,Maybe>]
+        # @return [Maybe<::Hash>]
+        #
+        def self.all(hash, trace = RightBiased::Left.trace_caller)
+          result = hash.each_with_object({}) do |(key, value), output|
+            if value.some?
+              output[key] = value.value!
+            else
+              return None.new(trace)
+            end
+          end
+
+          Some.new(result)
+        end
+
+        # Traverses a hash with maybe values. Some values are unwrapped, keys with
+        # None values are removed
+        #
+        # @example
+        #   Maybe::Hash.filter(foo: Some(1), bar: Some(2)) # => Some(foo: 1, bar: 2)
+        #   Maybe::Hash.filter(foo: Some(1), bar: None())  # => None()
+        #   Maybe::Hash.filter(foo: None(), bar: Some(2))  # => None()
+        #
+        # @param hash [::Hash<Object,Maybe>]
+        # @return [::Hash]
+        #
+        def self.filter(hash)
+          hash.each_with_object({}) do |(key, value), output|
+            output[key] = value.value! if value.some?
+          end
+        end
+      end
     end
 
     extend Maybe::Mixin::Constructors

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -503,4 +503,42 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
     end
   end
+
+  describe maybe::Hash do
+    let(:hash) { described_class }
+
+    describe '.all' do
+      it 'traverses all values' do
+        expect(hash.all(foo: some['123'], bar: some['234'])).to eql(
+          some[foo: '123', bar: '234']
+        )
+      end
+
+      it 'returns None if any value is None' do
+        expect(hash.all(foo: none, bar: some['234'])).to eql(none)
+        expect(hash.all(foo: some['123'], bar: none)).to eql(none)
+      end
+
+      it 'returns Some({}) for an empty hash' do
+        expect(hash.all({})).to eql(some[{}])
+      end
+    end
+
+    describe '.filter' do
+      it 'keeps some values and unwraps them' do
+        expect(hash.filter(foo: some['123'], bar: some['234'])).to eql(
+          foo: '123', bar: '234'
+        )
+      end
+
+      it 'skips none values' do
+        expect(hash.filter(foo: none, bar: some['234'])).to eql(bar: '234')
+        expect(hash.filter(foo: some['123'], bar: none)).to eql(foo: '123')
+      end
+
+      it 'returns {} for an empty hash' do
+        expect(hash.filter({})).to eql({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds two traversal methods for working with homogeneous hashes/maps/dicts These functions are simple but can be useful so it makes sense to have it in the library.

Examples for `all`:
```ruby
Maybe::Hash.all(foo: Some(1), bar: Some(2)) # => Some(foo: 1, bar: 2)
Maybe::Hash.all(foo: Some(1), bar: None())  # => None()
Maybe::Hash.all(foo: None(), bar: Some(2))  # => None()
```

Examples for `filter`:

```ruby
Maybe::Hash.filter(foo: Some(1), bar: Some(2)) # => Some(foo: 1, bar: 2)
Maybe::Hash.filter(foo: Some(1), bar: None())  # => None()
Maybe::Hash.filter(foo: None(), bar: Some(2))  # => None() 
```