### PR TITLE
Add experimental support for pattern matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 cache: bundler
 bundler_args: --without benchmarks docs
 script:
-  - bundle exec rake spec
+  - bundle exec rspec spec $RSPEC_OPTS
 before_install:
   - gem update --system
   - gem install bundler
@@ -18,7 +18,11 @@ env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
     - COVERAGE=true
+    - RSPEC_OPTS='--exclude-pattern spec/integration/pattern_matching_spec.rb'
 matrix:
+  include:
+    - rvm: 2.7
+      env: "RSPEC_OPTS=''"
   allow_failures:
     - rvm: ruby-head
 

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -365,6 +365,20 @@ module Dry
         end
       end
 
+      # Pattern matching
+      #
+      # @example
+      #   case List[1, 2, 3]
+      #   in List[1, 2, x] then ...
+      #   in List[Integer, _, _] then ...
+      #   in List[0..2, _, _] then ...
+      #   end
+      #
+      # @api private
+      def deconstruct
+        value
+      end
+
       private
 
       def coerce(other)

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -134,6 +134,7 @@ module Dry
       # @api public
       class None < Maybe
         include RightBiased::Left
+        include Core::Constants
 
         @instance = new.freeze
         singleton_class.send(:attr_reader, :instance)
@@ -204,6 +205,20 @@ module Dry
         # @private
         def hash
           None.instance.object_id
+        end
+
+        # Pattern matching
+        #
+        # @example
+        #   case Some(:foo)
+        #   in Some(Integer) then ...
+        #   in Some(:bar) then ...
+        #   in None() then ...
+        #   end
+        #
+        # @api private
+        def deconstruct
+          EMPTY_ARRAY
         end
       end
 

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -186,6 +186,25 @@ module Dry
           end
         end
 
+        # Pattern matching
+        #
+        # @example
+        #   case Success(x)
+        #   in Success(Integer) then ...
+        #   in Success(2..100) then ...
+        #   in Success(2..200 => code) then ...
+        #   end
+        # @api private
+        def deconstruct
+          if Unit.equal?(@value)
+            []
+          elsif @value.is_a?(::Array)
+            @value
+          else
+            [@value]
+          end
+        end
+
         private
 
         # @api private
@@ -302,6 +321,27 @@ module Dry
         # @return [RightBiased::Left]
         def and(_)
           self
+        end
+
+        # Pattern matching
+        #
+        # @example
+        #   case Success(x)
+        #   in Success(Integer) then ...
+        #   in Success(2..100) then ...
+        #   in Success(2..200 => code) then ...
+        #   in Failure(_) then ...
+        #   end
+        #
+        # @api private
+        def deconstruct
+          if Unit.equal?(@value)
+            []
+          elsif @value.is_a?(::Array)
+            @value
+          else
+            [@value]
+          end
         end
       end
     end

--- a/spec/integration/pattern_matching_spec.rb
+++ b/spec/integration/pattern_matching_spec.rb
@@ -1,0 +1,131 @@
+RSpec.describe 'pattern matching' do
+  context 'Result' do
+    include Dry::Monads[:result]
+
+    context 'Success' do
+      let(:match) { Test::Context.new }
+
+      specify 'destructuring' do
+        class Test::Context
+          include Dry::Monads[:result]
+
+          def call(value)
+            case value
+            in Failure(_) then :failure
+            in Success(10) then :ten
+            in Success(100..500 => code) then code
+            in Success() then :empty
+            in Success(:code, x) then x
+            in Success[:status, x] then x
+            in Success({ status: x }) then x
+            in Success({ code: 200..300 => x }) then x
+            end
+          end
+        end
+
+        expect(match.(Success(10))).to eql(:ten)
+        expect(match.(Success())).to eql(:empty)
+        expect(match.(Success(400))).to eql(400)
+        expect(match.(Success([:code, 600]))).to eql(600)
+        expect(match.(Success([:status, 600]))).to eql(600)
+        expect(match.(Success({ status: 404 }))).to eql(404)
+        expect(match.(Success({ code: 204 }))).to eql(204)
+      end
+    end
+
+    context 'Failure' do
+      let(:match) { Test::Context.new }
+
+      specify 'destructuring' do
+        class Test::Context
+          include Dry::Monads[:result]
+
+          def call(value)
+            case value
+            in Failure[:not_found, reason] then reason
+            in Failure(:error) then :nope
+            in Failure() then :unit
+            end
+          end
+        end
+
+        expect(match.(Failure([:not_found, :no]))).to eql(:no)
+        expect(match.(Failure(:error))).to eql(:nope)
+        expect(match.(Failure())).to eql(:unit)
+        expect { match.(Failure(3)) }.to raise_error(NoMatchingPatternError)
+      end
+    end
+  end
+
+  context 'Maybe' do
+    include Dry::Monads[:maybe]
+
+    let(:match) { Test::Context.new }
+
+    specify 'destructuring' do
+      class Test::Context
+        include Dry::Monads[:maybe]
+
+        def call(value)
+          case value
+          in Some[:foo, x] then x
+          in Some(Integer => x) then x
+          in None() then :nothing
+          end
+        end
+      end
+
+      expect(match.(Some([:foo, :payload]))).to eql(:payload)
+      expect(match.(Some(30))).to eql(30)
+      expect(match.(None())).to eql(:nothing)
+    end
+
+    specify 'none alt' do
+      class Test::Context
+        include Dry::Monads[:maybe]
+
+        def call(value)
+          case value
+          in None then :nothing
+          end
+        end
+      end
+
+      expect(match.(None())).to eql(:nothing)
+    end
+  end
+
+  context 'List' do
+    include Dry::Monads[:list, :maybe]
+
+    let(:match) { Test::Context.new }
+
+    specify 'destructuring' do
+      class Test::Context
+        include Dry::Monads[:list, :maybe]
+
+        def call(value)
+          case value
+          in List[Some[:foo, x]] then x
+          in List[_, Some(:else)] then :else
+          in List[] then :empty
+          in List[Integer => x] then x
+          in List[Time] | List[Date] then :date_or_time
+          in List[String | Symbol] then :string_or_symbol
+          end
+        end
+      end
+
+      list = Dry::Monads::List
+
+      expect(match.(list[Some([:foo, :payload])])).to eql(:payload)
+      expect(match.(list[Some([:foo, :payload]), Some(:else)])).to eql(:else)
+      expect(match.(list[])).to eql(:empty)
+      expect(match.(list[5])).to eql(5)
+      expect(match.(list[Time.now])).to eql(:date_or_time)
+      expect(match.(list[Date.today])).to eql(:date_or_time)
+      expect(match.(list[:sym])).to eql(:string_or_symbol)
+      expect(match.(list['sym'])).to eql(:string_or_symbol)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ end
 
 require 'warning'
 Warning.ignore(/rspec\/core/)
+Warning.ignore(/Pattern matching/)
 
 begin
   require 'pry'


### PR DESCRIPTION
This adds support for ruby 2.7+ PM:
```ruby
case value
in Failure(_) then :failure
in Success(10) then :ten
in Success(100..500 => code) then code
in Success() then :empty
in Success(:code, x) then x
in Success[:status, x] then x
in Success({ status: x }) then x
in Success({ code: 200..300 => x }) then x
end
```