### PR TITLE
Add Maybe#maybe

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -119,8 +119,9 @@ module Dry
         # @return [Maybe::Some, Maybe::None] Wrapped result, i.e. nil will be mapped to None,
         #                                    other values will be wrapped with Some
         def fmap(*args, &block)
-          self.class.coerce(bind(*args, &block))
+          Maybe.coerce(bind(*args, &block))
         end
+        alias_method :maybe, :fmap
 
         # @return [String]
         def to_s

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -137,6 +137,12 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
     end
 
+    describe '#maybe' do
+      it 'is an alias for fmap' do
+        expect(subject.method(:maybe)).to eql(subject.method(:fmap))
+      end
+    end
+
     describe '#or' do
       it 'accepts a value as an alternative' do
         expect(subject.or(some['baz'])).to be(subject)


### PR DESCRIPTION
At the moment, Maybe#fmap violates the functor laws because it coerces nil values to None. This ruins predictability of composition. Changing current behavior would be a breaking change so I won't do this. This commit instead adds `Maybe#maybe`, an alias for `fmap` that does coercing too. In future, calling `fmap` with a block returning `nil` will issue a warning, in 2.0 this warning will be turned into an error.