### PR TITLE
Show Unit as empty parens in right-biased monads

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -125,7 +125,11 @@ module Dry
 
         # @return [String]
         def to_s
-          "Some(#{ @value.inspect })"
+          if Unit.equal?(@value)
+            'Some()'
+          else
+            "Some(#{@value.inspect})"
+          end
         end
         alias_method :inspect, :to_s
       end

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -131,7 +131,11 @@ module Dry
 
         # @return [String]
         def to_s
-          "Success(#{ @value.inspect })"
+          if Unit.equal?(@value)
+            'Success()'
+          else
+            "Success(#{@value.inspect})"
+          end
         end
         alias_method :inspect, :to_s
 
@@ -240,7 +244,11 @@ module Dry
 
         # @return [String]
         def to_s
-          "Failure(#{ @value.inspect })"
+          if Unit.equal?(@value)
+            'Failure()'
+          else
+            "Failure(#{@value.inspect})"
+          end
         end
         alias_method :inspect, :to_s
 

--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -128,14 +128,18 @@ module Dry
       def to_s
         state = case promise.state
                 when :fulfilled
-                  "value=#{ value!.inspect }"
+                  if Unit.equal?(value!)
+                    'value=()'
+                  else
+                    "value=#{value!.inspect}"
+                  end
                 when :rejected
                   "error=#{ promise.reason.inspect }"
                 else
                   '?'
                 end
 
-        "Task(#{ state })"
+        "Task(#{state})"
       end
       alias_method :inspect, :to_s
 

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -156,7 +156,11 @@ module Dry
 
         # @return [String]
         def to_s
-          "Try::Value(#{ @value.inspect })"
+          if Unit.equal?(@value)
+            'Try::Value()'
+          else
+            "Try::Value(#{@value.inspect})"
+          end
         end
         alias_method :inspect, :to_s
       end

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -120,7 +120,11 @@ module Dry
 
         # @return [String]
         def inspect
-          "Valid(#{ value!.inspect })"
+          if Unit.equal?(@value)
+            "Valid()"
+          else
+            "Valid(#{@value.inspect})"
+          end
         end
         alias_method :to_s, :inspect
 

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe(Dry::Monads::Maybe) do
 
     it 'dumps to string' do
       expect(subject.to_s).to eql('Some("foo")')
+      expect(some[unit].to_s).to eql('Some()')
     end
 
     it 'has custom inspection' do

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe(Dry::Monads::Result) do
 
     it 'dumps to string' do
       expect(subject.to_s).to eql('Success("foo")')
+      expect(success[unit].to_s).to eql('Success()')
     end
 
     it 'has custom inspection' do
@@ -334,6 +335,7 @@ RSpec.describe(Dry::Monads::Result) do
 
     it 'dumps to string' do
       expect(subject.to_s).to eql('Failure("bar")')
+      expect(failure[unit].to_s).to eql('Failure()')
     end
 
     it 'has custom inspection' do

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe(Dry::Monads::Task) do
 
   maybe = Dry::Monads::Maybe
   some = maybe::Some.method(:new)
+  unit = Dry::Monads::Unit
 
   task = described_class
 
@@ -121,6 +122,10 @@ RSpec.describe(Dry::Monads::Task) do
       1 / 0 rescue err = $!
       t = task { raise err }.tap(&:to_result)
       expect(t.inspect).to eql("Task(error=#{ err.inspect })")
+    end
+
+    it 'shows empty parens for unit' do
+      expect(task { unit }.tap(&:value!).to_s).to eql('Task(value=())')
     end
   end
 

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe(Dry::Monads::Try) do
   value = try::Value.method(:new)
   div_value = -> v { value[[ZeroDivisionError], v] }
   error = try::Error.method(:new)
+  unit = Dry::Monads::Unit
 
   division_error = 1 / 0 rescue $ERROR_INFO
   no_method_error = no_method rescue $ERROR_INFO
@@ -54,6 +55,7 @@ RSpec.describe(Dry::Monads::Try) do
 
     it 'dumps to string' do
       expect(subject.to_s).to eql('Try::Value("foo")')
+      expect(value[[], unit].to_s).to eql('Try::Value()')
     end
 
     it 'has custom inspection' do

--- a/spec/unit/validated_spec.rb
+++ b/spec/unit/validated_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe(Dry::Monads::Validated) do
   invalid = described_class::Invalid.method(:new)
   maybe = Dry::Monads::Maybe
   some = maybe::Some.method(:new)
+  unit = Dry::Monads::Unit
 
   result = Dry::Monads::Result
   success = result::Success.method(:new)
@@ -33,6 +34,7 @@ RSpec.describe(Dry::Monads::Validated) do
     describe '#inspect' do
       it 'returns the string representation' do
         expect(subject.inspect).to eql("Valid(1)")
+        expect(valid[unit].inspect).to eql("Valid()")
       end
     end
 


### PR DESCRIPTION
This makes it consistent with constructors. It could be somewhat confusing, though. If you don't read the docs.