### PR TITLE
CI: Use 2.4.7, 2.5.6, 2.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_install:
 after_success:
   - "[ -d coverage ] && bundle exec codeclimate-test-reporter"
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
   - jruby-9.2.7.0
 env:
   global:


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known