### PR TITLE
Skip stacktrace allocation in Do.halt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :tools do
   gem 'pry-byebug', platform: :mri
   gem 'pry', platform: :jruby
   gem 'ossy', github: 'solnic/ossy', branch: 'master'
+  gem 'benchmark-ips'
 end
 
 group :docs do

--- a/lib/dry/monads.rb
+++ b/lib/dry/monads.rb
@@ -1,3 +1,4 @@
+require 'dry/core/constants'
 require 'dry/monads/registry'
 
 module Dry

--- a/lib/dry/monads/constants.rb
+++ b/lib/dry/monads/constants.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'dry/core/constants'
 
 module Dry
   module Monads
     # @private
-    Undefined = Dry::Core::Constants::Undefined
+    include Core::Constants
   end
 end

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -1,5 +1,6 @@
 require 'dry/monads/list'
 require 'dry/monads/do/mixin'
+require 'dry/monads/constants'
 
 module Dry
   module Monads
@@ -130,7 +131,7 @@ module Dry
 
         # @api private
         def halt(result)
-          raise Halt.new(result)
+          raise Halt.new(result), EMPTY_STRING, EMPTY_ARRAY
         end
       end
     end

--- a/lib/dry/monads/do/all.rb
+++ b/lib/dry/monads/do/all.rb
@@ -56,7 +56,7 @@ module Dry
       #
       module All
         # @private
-        class MethodTracker < Module
+        class MethodTracker < ::Module
           attr_reader :wrappers
 
           def initialize(wrappers)
@@ -80,7 +80,7 @@ module Dry
 
               def included(base)
                 super
-                Dry::Monads::Do::All.included(base)
+                All.included(base)
               end
             end
           end

--- a/lib/dry/monads/do/mixin.rb
+++ b/lib/dry/monads/do/mixin.rb
@@ -43,14 +43,13 @@ module Dry
         # @api public
         def bind(monads)
           monads = Do.coerce_to_monad(Array(monads))
-          unwrapped = monads.map { |result|
+          unwrapped = monads.map do |result|
             monad = result.to_monad
             monad.or { Do.halt(monad) }.value!
-          }
+          end
           monads.size == 1 ? unwrapped[0] : unwrapped
         end
       end
     end
   end
 end
-

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -1,11 +1,10 @@
 require 'dry/equalizer'
-require 'dry/core/constants'
 require 'dry/core/deprecations'
 
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
 require 'dry/monads/unit'
-require 'dry/monads/undefined'
+require 'dry/monads/constants'
 
 module Dry
   module Monads
@@ -16,7 +15,7 @@ module Dry
       include Transformer
 
       class << self
-        extend Dry::Core::Deprecations[:'dry-monads']
+        extend Core::Deprecations[:'dry-monads']
 
         # Wraps the given value with into a Maybe object.
         #
@@ -139,7 +138,6 @@ module Dry
       # @api public
       class None < Maybe
         include RightBiased::Left
-        include Core::Constants
 
         @instance = new.freeze
         singleton_class.send(:attr_reader, :instance)

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -1,6 +1,6 @@
 require 'dry/equalizer'
 
-require 'dry/monads/undefined'
+require 'dry/monads/constants'
 require 'dry/monads/right_biased'
 require 'dry/monads/transformer'
 require 'dry/monads/conversion_stubs'

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -1,5 +1,4 @@
-require 'dry/core/constants'
-
+require 'dry/monads/constants'
 require 'dry/monads/unit'
 require 'dry/monads/curry'
 require 'dry/monads/errors'
@@ -12,8 +11,6 @@ module Dry
       #
       # @api public
       module Right
-        include Dry::Core::Constants
-
         # @private
         def self.included(m)
           super

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -1,5 +1,5 @@
 require 'dry/monads/conversion_stubs'
-require 'dry/monads/undefined'
+require 'dry/monads/constants'
 require 'dry/monads/right_biased'
 
 module Dry


### PR DESCRIPTION
This improves performance of a trivial failing case up to 25-30%:

```ruby
class Operation
  include Dry::Monads[:result, :do]

  Error = Dry::Monads.Failure()

  def call
    yield Error
  end
end
```