### PR TITLE
Add support for deconstruct_keys

### DIFF
--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -191,6 +191,7 @@ module Dry
         #   in Success(2..100) then ...
         #   in Success(2..200 => code) then ...
         #   end
+        #
         # @api private
         def deconstruct
           if Unit.equal?(@value)
@@ -199,6 +200,25 @@ module Dry
             @value
           else
             [@value]
+          end
+        end
+
+        # Pattern matching hash values
+        #
+        # @example
+        #   case Success(x)
+        #   in Success(code: 200...300) then :ok
+        #   in Success(code: 300...400) then :redirect
+        #   in Success(code: 400...500) then :user_error
+        #   in Success(code: 500...600) then :server_error
+        #   end
+        #
+        # @api private
+        def deconstruct_keys(_)
+          if @value.is_a?(::Hash)
+            @value
+          else
+            EMPTY_HASH
           end
         end
 
@@ -338,6 +358,23 @@ module Dry
             @value
           else
             [@value]
+          end
+        end
+
+        # Pattern matching hash values
+        #
+        # @example
+        #   case Failure(x)
+        #   in Failure(code: 400...500) then :user_error
+        #   in Failure(code: 500...600) then :server_error
+        #   end
+        #
+        # @api private
+        def deconstruct_keys(_)
+          if @value.is_a?(::Hash)
+            @value
+          else
+            EMPTY_HASH
           end
         end
       end

--- a/spec/integration/pattern_matching_spec.rb
+++ b/spec/integration/pattern_matching_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'pattern matching' do
             in Success(:code, x) then x
             in Success[:status, x] then x
             in Success({ status: x }) then x
+            in Success(code: 301 | 302) then :redirect
             in Success({ code: 200..300 => x }) then x
             end
           end
@@ -32,6 +33,10 @@ RSpec.describe 'pattern matching' do
         expect(match.(Success([:status, 600]))).to eql(600)
         expect(match.(Success({ status: 404 }))).to eql(404)
         expect(match.(Success({ code: 204 }))).to eql(204)
+        expect(match.(Success(code: 301))).to eql(:redirect)
+        expect(match.(Success(code: 302))).to eql(:redirect)
+        expect { match.(Success(code: 303)) }.to raise_error(NoMatchingPatternError)
+        expect { match.(Success([:foo])) }.to raise_error(NoMatchingPatternError)
       end
     end
 
@@ -46,6 +51,7 @@ RSpec.describe 'pattern matching' do
             case value
             in Failure[:not_found, reason] then reason
             in Failure(:error) then :nope
+            in Failure(error: code) then code
             in Failure() then :unit
             end
           end
@@ -54,6 +60,7 @@ RSpec.describe 'pattern matching' do
         expect(match.(Failure([:not_found, :no]))).to eql(:no)
         expect(match.(Failure(:error))).to eql(:nope)
         expect(match.(Failure())).to eql(:unit)
+        expect(match.(Failure(error: :bug))).to eql(:bug)
         expect { match.(Failure(3)) }.to raise_error(NoMatchingPatternError)
       end
     end


### PR DESCRIPTION
This saves us from writing curly braces when the wrapped value is a hash.

Before:
```ruby
case result
in Success({ code: 200...300 }) then :ok
in Success({ code: 300...400 }) then :redirect
in Success({ code: 400...500 }) then :user_error
in Success({ code: 500...600 }) then :server_error
end
```

After:
```ruby
case result
in Success(code: 200...300) then :ok
in Success(code: 300...400) then :redirect
in Success(code: 400...500) then :user_error
in Success(code: 500...600) then :server_error
end
```