### PR TITLE
Fix keyword warnings

### DIFF
--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -224,9 +224,20 @@ module Dry
 
         private
 
-        # @api private
-        def destructure(*args, **kwargs)
-          [args, kwargs]
+        if RUBY_VERSION >= '2.7'
+          # @api private
+          def destructure(value)
+            if value.is_a?(::Hash)
+              [EMPTY_ARRAY, value]
+            else
+              [[value], EMPTY_HASH]
+            end
+          end
+        else
+          # @api private
+          def destructure(*args, **kwargs)
+            [args, kwargs]
+          end
         end
 
         # @api private

--- a/spec/integration/maybe_spec.rb
+++ b/spec/integration/maybe_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe(Dry::Monads::Maybe) do
     end
 
     context 'keywords' do
-      let(:build_name) { -> (first_name:, last_name:) { "#{ first_name } #{ last_name }" } }
+      let(:build_name) { -> (values) { "#{values.fetch(:first_name)} #{values.fetch(:last_name)}" } }
 
       it 'works' do
         expect(Some(build_name).apply(Some(first_name: 'John', last_name: 'Doe'))).to eql(Some('John Doe'))
@@ -130,7 +130,7 @@ RSpec.describe(Dry::Monads::Maybe) do
     end
 
     context 'mixed' do
-      let(:build_name) { -> (first_name, last_name:) { "#{ first_name } #{ last_name }" } }
+      let(:build_name) { -> (first_name, rest) { "#{first_name} #{rest.fetch(:last_name)}" } }
 
       it 'works' do
         expect(Some(build_name).apply(Some('John')).apply(Some(last_name: 'Doe'))).to eql(Some('John Doe'))

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -205,9 +205,9 @@ RSpec.describe(Dry::Monads::Result) do
 
       describe '#bind' do
         it 'passed extra keywords to block along with value' do
-          expr_result = subject.bind(bar: 'bar') do |foo:, bar: |
-            expect(foo).to eql('foo')
-            expect(bar).to eql('bar')
+          expr_result = subject.bind(bar: 'bar') do |values|
+            expect(values.fetch(:foo)).to eql('foo')
+            expect(values.fetch(:bar)).to eql('bar')
             true
           end
 
@@ -226,10 +226,10 @@ RSpec.describe(Dry::Monads::Result) do
 
       describe '#bind' do
         it 'passed extra keywords to block along with value' do
-          expr_result = subject.bind(:baz, quux: 'quux') do |value, baz, quux: |
+          expr_result = subject.bind(:baz, quux: 'quux') do |value, baz, rest|
             expect(value).to eql(subject.value!)
             expect(baz).to eql(:baz)
-            expect(quux).to eql('quux')
+            expect(rest.fetch(:quux)).to eql('quux')
             true
           end
 


### PR DESCRIPTION
This changes rules of destructuring values since starting Ruby 2.7 keyword arguments are allowed to be arbitrary objects. I simplified the check, for now, to make it semi-compatible, but I will remove it in the next major version. Programming with do notation is preferrable, and it doesn't require all these weird stuff I invented back in the dry-transaction days. 