### PR TITLE
Halt with mutable backtrace

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -131,7 +131,7 @@ module Dry
 
         # @api private
         def halt(result)
-          raise Halt.new(result), EMPTY_STRING, EMPTY_ARRAY
+          raise Halt.new(result), EMPTY_STRING, []
         end
       end
     end


### PR DESCRIPTION
Exceptions are typically raised with mutable backtraces. This fixes an
issue with spring where all backtraces are sanitized to remove spring
references. #115 