### PR TITLE
Delegate .deconstruct calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.3.6 2020-01-08
+
+## Added
+
+- Delegation of `.deconstruct` calls (flash-gordon)
+
+[Compare v1.3.5...v1.3.6](https://github.com/dry-rb/dry-monads/compare/v1.3.5...v1.3.6)
+
 # v1.3.5 2020-01-06
 
 ## Added

--- a/docsite/source/pattern-matching.html.md
+++ b/docsite/source/pattern-matching.html.md
@@ -66,3 +66,32 @@ in List[]
   # empty list
 end
 ```
+
+### Matching array values
+
+dry-monads treats all wrapped array values as tuples rather than lists.
+For examplle, this will not work:
+
+```ruby
+Success([1, 2, 3]) in Success(numbers) # => no match!
+```
+
+But this will:
+
+```ruby
+Success([1, 2, 3]) in Success(one, two, three)
+```
+
+And this will too:
+
+```ruby
+Success([1, 2, 3]) in Success[1, 2 ,3]
+```
+
+To capture an array value, use `*`:
+
+```ruby
+Success([1, 2, 3]) in Success(*numbers)
+```
+
+At least for `Failure` values, people use tuples more often; this is why dry-monads treats _all_ arrays as tuples. We could make `Success`/`Failure` behaviors different, but this would be even more unexpected.

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -196,10 +196,8 @@ module Dry
         #
         # @api private
         def deconstruct
-          if Unit.equal?(@value)
-            []
-          elsif @value.is_a?(::Array)
-            @value
+          if @value.respond_to?(:deconstruct)
+            @value.deconstruct
           else
             [@value]
           end

--- a/lib/dry/monads/unit.rb
+++ b/lib/dry/monads/unit.rb
@@ -26,6 +26,10 @@ module Dry
       def unit.inspect
         'Unit'
       end
+
+      def unit.deconstruct
+        EMPTY_ARRAY
+      end
     end
   end
 end

--- a/spec/integration/pattern_matching_spec.rb
+++ b/spec/integration/pattern_matching_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe 'pattern matching' do
         end
       end
 
+      let(:array_like) do
+        Object.new.tap do |o|
+          def o.deconstruct
+            [4, 9, 16]
+          end
+        end
+      end
+
       specify 'destructuring' do
         class Test::Context
           include Dry::Monads[:result]
@@ -30,6 +38,9 @@ RSpec.describe 'pattern matching' do
             in Success(code: 301 | 302) then :redirect
             in Success({ code: 200..300 => x }) then x
             in Success(code: 101) then :switch_protocol
+            in Success(1, 2) then :ein_zwei
+            in Success[3, 4] then :drei_vier
+            in Success(*array) if array.size > 1 then array
             end
           end
         end
@@ -45,6 +56,9 @@ RSpec.describe 'pattern matching' do
         expect(match.(Success(code: 301))).to eql(:redirect)
         expect(match.(Success(code: 302))).to eql(:redirect)
         expect(match.(Success(hash_like))).to eql(:switch_protocol)
+        expect(match.(Success([1, 2]))).to eql(:ein_zwei)
+        expect(match.(Success([3, 4]))).to eql(:drei_vier)
+        expect(match.(Success(array_like))).to eql([4, 9, 16])
 
         expect { match.(Success(code: 303)) }.to raise_error(NoMatchingPatternError)
         expect { match.(Success([:foo])) }.to raise_error(NoMatchingPatternError)


### PR DESCRIPTION
Similar to how `deconstruct_keys` is delegated. Also, `Unit` is automatically deconstructed as an empty array.
It is important to understand dry-monads treats wrapped arrays as tuples and not lists. This is a compromise that can lead to some confusion. For example, this will not work:
```ruby
Success([1, 2, 3]) in Success(numbers) # => no match!
```
But this will:
```ruby
Success([1, 2, 3]) in Success(one, two, three)
```
And this will too:
```ruby
Success([1, 2, 3]) in Success[one, two, three]
```
To match an array `*` is required:
```ruby
Success([1, 2, 3]) in Success(*numbers)
```
At least for `Failure` values, people use tuples more often; this is why dry-monads treats _all_ arrays as tuples. We could make `Success`/`Failure` behaviors different, but this would be even more unexpected. Instead, I'll just document this caveat. If ruby had tuples OOTB (like python), there would have been no trouble.