### PR TITLE
Revert .destruct delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# v1.3.6 2020-01-08
+# unreleased
 
 ## Added
 
-- Delegation of `.deconstruct` calls (flash-gordon)
+- `Unit` destructures to an empty array (flash-gordon)
 
-[Compare v1.3.5...v1.3.6](https://github.com/dry-rb/dry-monads/compare/v1.3.5...v1.3.6)
+[Compare v1.3.5...master](https://github.com/dry-rb/dry-monads/compare/v1.3.5...master)
 
 # v1.3.5 2020-01-06
 

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -196,10 +196,12 @@ module Dry
         #
         # @api private
         def deconstruct
-          if @value.respond_to?(:deconstruct)
-            @value.deconstruct
-          else
+          if Unit.equal?(@value)
+            EMPTY_ARRAY
+          elsif !@value.is_a?(::Array)
             [@value]
+          else
+            @value
           end
         end
 


### PR DESCRIPTION
This broke cases like matching Success(Some(x)). I added a spec, ensuring it won't break again. The absence of delegation creates some inconveniences requiring adding parens when matching. These cases, however, are quite exceptional and shouldn't occur too often.