### PR TITLE
Add method_missing to Maybe, which delegates to #fmap

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -83,6 +83,12 @@ module Dry
         Maybe
       end
 
+      # Convenient way to call #maybe on an instance
+      def method_missing(*args, &block)
+        fmap do |value|
+          value.public_send(*args, &block)
+        end
+      end
       # Represents a value that is present, i.e. not nil.
       #
       # @api public

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -84,11 +84,25 @@ module Dry
       end
 
       # Convenient way to call #fmap on an instance
+      #
+      # @api private
       def method_missing(*args, &block)
         fmap do |value|
           value.public_send(*args, &block)
         end
       end
+
+      # @api private
+      def respond_to_missing?(method_name, include_private = false)
+        if none?
+          true
+        elsif some?
+          @value.respond_to?(method_name, include_private)
+        else
+          super
+        end
+      end
+
       # Represents a value that is present, i.e. not nil.
       #
       # @api public

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -83,7 +83,7 @@ module Dry
         Maybe
       end
 
-      # Convenient way to call #maybe on an instance
+      # Convenient way to call #fmap on an instance
       def method_missing(*args, &block)
         fmap do |value|
           value.public_send(*args, &block)

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -146,6 +146,12 @@ RSpec.describe(Dry::Monads::Maybe) do
       end
     end
 
+    describe "#method_missing" do
+      it "delegates calls to #fmap" do
+        expect(subject.upcase).to eql(upcased_subject)
+      end
+    end
+
     describe '#or' do
       it 'accepts a value as an alternative' do
         expect(subject.or(some['baz'])).to be(subject)


### PR DESCRIPTION
Definitely opinionated and the lack of explicitness could be a bad idea, but I like it as it makes your code cleaner. I completely understand if you don't want to merge this, just an idea.

This change adds `method_missing` to `Maybe` which delegates calls to `#fmap`.

Instead of writing:

```ruby
thing.fmap { |t| t.some_method('with', 'args') }.fmap { |t| t.another_method(123) }
```

You can do:

```ruby
thing.some_method('with', 'args').another_method(123)
```