### PR TITLE
Preserve visibility when including Dry::Monads::Do

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -85,7 +85,7 @@ module Dry
         # @return [Module]
         def for(*methods)
           mod = ::Module.new do
-            methods.each { |method_name| Do.wrap_method(self, method_name) }
+            methods.each { |method_name| Do.wrap_method(self, method_name, :public) }
           end
 
           ::Module.new do
@@ -105,7 +105,7 @@ module Dry
         end
 
         # @api private
-        def wrap_method(target, method_name)
+        def wrap_method(target, method_name, visibility)
           target.module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
             def #{method_name}(#{DELEGATE})
               if block_given?
@@ -114,6 +114,7 @@ module Dry
                 Do.() { super { |*ms| Do.bind(ms) } }
               end
             end
+            #{visibility} :#{method_name}
           RUBY
         end
 

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -83,9 +83,17 @@ module Dry
         #
         # @param [Array<Symbol>] methods
         # @return [Module]
-        def for(*methods)
+        def for(*public_methods, **methods_with_visibility)
           mod = ::Module.new do
-            methods.each { |method_name| Do.wrap_method(self, method_name, :public) }
+            public_methods.each do |method_name|
+              Do.wrap_method(self, method_name, nil)
+            end
+
+            methods_with_visibility.each do |visibility, methods|
+              methods.each do |method_name|
+                Do.wrap_method(self, method_name, visibility)
+              end
+            end
           end
 
           ::Module.new do

--- a/spec/integration/do_for_spec.rb
+++ b/spec/integration/do_for_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "dry/monads/do"
+
+RSpec.describe(Dry::Monads::Do) do
+  result_mixin = Dry::Monads::Result::Mixin
+  include result_mixin
+
+  describe ".for" do
+    let(:input_value) { 10 }
+    let(:equation) do
+      klass = Class.new do
+        include Dry::Monads::Do.for(:answer, protected: [:square], private: [:double])
+
+        def initialize(starting_value)
+          @starting_value = starting_value
+        end
+
+        def answer
+          c = yield(square) + yield(double)
+          Success(c)
+        end
+
+        protected
+
+        def square
+          s = yield(starting_value) * yield(starting_value)
+          Success(s)
+        end
+
+        private
+
+        def double
+          d = yield(starting_value) + yield(starting_value)
+          Success(d)
+        end
+
+        attr_reader :starting_value
+      end
+      klass.tap { |c| c.include(result_mixin) }.new(Success(input_value))
+    end
+
+    it "can call a public method" do
+      expect { equation.answer }.to_not raise_error
+    end
+
+    it "works" do
+      expect(equation.answer).to eq(Success(120))
+    end
+
+    it "cannot call a protected method directly" do
+      expect { equation.square }.to raise_error(NoMethodError)
+    end
+
+    it "cannot call a private method directly" do
+      expect { equation.double }.to raise_error(NoMethodError)
+    end
+  end
+end


### PR DESCRIPTION
* Closes #128.
* Proposed API enhancement for Do.for()

[As discussed over on Discourse][1], it's difficult to
fix `Do.for` without additional help from the user. I've included a proposal
on how that could be achieved with no breaking changes - but
if the team would rather accept the patches for `Do::All` and
leave `Do.for()` for a later time, that's fine with me as well.


[1]: https://discourse.dry-rb.org/t/monads-do-strips-visibility-modifiers-from-methods/1098/4