### PR TITLE
Document that Do::All won't wrap ancestor methods

### DIFF
--- a/docsite/source/do-notation.html.md
+++ b/docsite/source/do-notation.html.md
@@ -150,6 +150,8 @@ class CreateAccount
 end
 ```
 
+Note that `Do::All` will not automatically pass a block to methods inherited from ancestors, such as included modules or a parent class.
+
 ### Using `Do` methods in other contexts
 
 You can use methods from the `Do` module directly (starting with 1.3):


### PR DESCRIPTION
When `Do::All` is included, it specifically excludes methods inherited from ancestors such as included modules or parent classes. This is likely very intentional to avoid wrapping methods right up the hierarchy.

I discovered this limitation when putting some shared logic in a module that two classes using `Do::All` could include, to discover that it doesn't work. A workaround is to instead have the module `class_eval` the instance methods onto the class.