### PR TITLE
Fix doc typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 This library officially supports the following Ruby versions:
 
-* MRI >= `2.5
+* MRI >= `2.5`
 * jruby >= `9.2`
 
 ## License

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -345,7 +345,7 @@ module Dry
       #       Some(n / divisor)
       #     end
       #   end
-      #   # => List[4, 2]
+      #   # => List[2, 4]
       #
       # @example without block
       #   List[Some(5), None(), Some(3)].collect.map { |x| x * 2 }

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -422,10 +422,10 @@ module Dry
       # List of results
       Result = ListBuilder[Result]
 
-      # List of results
+      # List of maybes
       Maybe = ListBuilder[Maybe]
 
-      # List of results
+      # List of tries
       Try = ListBuilder[Try]
 
       # List of validation results

--- a/lib/dry/monads/list.rb
+++ b/lib/dry/monads/list.rb
@@ -329,7 +329,7 @@ module Dry
 
       # Returns self.
       #
-      # @return [Result::Success, Result::Failure]
+      # @return [List]
       def to_monad
         self
       end

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -301,9 +301,9 @@ module Dry
         # None values are removed
         #
         # @example
-        #   Maybe::Hash.filter(foo: Some(1), bar: Some(2)) # => Some(foo: 1, bar: 2)
-        #   Maybe::Hash.filter(foo: Some(1), bar: None())  # => None()
-        #   Maybe::Hash.filter(foo: None(), bar: Some(2))  # => None()
+        #   Maybe::Hash.filter(foo: Some(1), bar: Some(2)) # => { foo: 1, bar: 2 }
+        #   Maybe::Hash.filter(foo: Some(1), bar: None())  # => { foo: 1 }
+        #   Maybe::Hash.filter(foo: None(), bar: Some(2))  # => { bar: 2 }
         #
         # @param hash [::Hash<Object,Maybe>]
         # @return [::Hash]

--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -325,7 +325,7 @@ module Dry
 
     class Result
       class Success < Result
-        # @return [Maybe::Some]
+        # @return [Maybe]
         def to_maybe
           Kernel.warn "Success(nil) transformed to None" if @value.nil?
           Dry::Monads::Maybe(@value)

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -448,7 +448,7 @@ module Dry
       end
 
       class Invalid < Validated
-        # Concerts to Result::Failure
+        # Converts to Result::Failure
         #
         # @return [Result::Failure]
         def to_result

--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -302,8 +302,8 @@ module Dry
         # A lifted version of `#or`. This is basically `#or` + `#fmap`.
         #
         # @example
-        #   Dry::Monads.None.or('no value') # => Some("no value")
-        #   Dry::Monads.None.or { Time.now } # => Some(current time)
+        #   Dry::Monads.None.or_fmap('no value') # => Some("no value")
+        #   Dry::Monads.None.or_fmap { Time.now } # => Some(current time)
         #
         # @return [RightBiased::Left, RightBiased::Right]
         def or_fmap(*)

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -263,7 +263,7 @@ module Dry
           v = Undefined.default(value, block)
           raise ArgumentError, "No value given" if !value.nil? && v.nil?
 
-          Value.new(exceptions, v)
+          Try::Value.new(exceptions, v)
         end
 
         # Error constructor

--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -92,7 +92,7 @@ module Dry
 
       # Returns self.
       #
-      # @return [Maybe::Some, Maybe::None]
+      # @return [Try::Value, Try::Error]
       def to_monad
         self
       end

--- a/lib/dry/monads/validated.rb
+++ b/lib/dry/monads/validated.rb
@@ -86,7 +86,6 @@ module Dry
         #   @yieldreturn [Validated::Valid,Validated::Invalid]
         #   @return [Validated::Valid,Validated::Invalid]
         #
-        # @return [Validated::Valid]
         def apply(val = Undefined)
           Undefined.default(val) { yield }.fmap(Curry.(value!))
         end
@@ -297,7 +296,7 @@ module Dry
       class Failure < Result
         # Transforms to Validated
         #
-        # @return [Validated::Valid]
+        # @return [Validated::Invalid]
         def to_validated
           Validated::Invalid.new(failure, trace)
         end


### PR DESCRIPTION
Here are some corrections of typos that I have noticed in the documentation of some methods and in the readme.