### PR TITLE
Keep method visibility when Do{.for, ::All} included

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,6 +1,8 @@
 ---
 - version: unreleased
-  date: 
+  date:
+  fixed:
+  - Do notation preserves method visibility (anicholson + flash-gordon)
   added:
   - "`Unit` destructures to an empty array (flash-gordon)"
 - version: 1.3.5

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -85,7 +85,7 @@ module Dry
         # @return [Module]
         def for(*methods)
           mod = ::Module.new do
-            methods.each { |method_name| Do.wrap_method(self, method_name) }
+            methods.each { |method_name| Do.wrap_method(self, method_name, :public) }
           end
 
           ::Module.new do
@@ -105,7 +105,7 @@ module Dry
         end
 
         # @api private
-        def wrap_method(target, method_name)
+        def wrap_method(target, method_name, visibility)
           target.module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
             def #{method_name}(#{DELEGATE})
               if block_given?
@@ -114,6 +114,7 @@ module Dry
                 Do.() { super { |*ms| Do.bind(ms) } }
               end
             end
+            #{visibility} :#{method_name}
           RUBY
         end
 

--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -83,9 +83,17 @@ module Dry
         #
         # @param [Array<Symbol>] methods
         # @return [Module]
-        def for(*methods)
+        def for(*public_methods, **methods_with_visibility)
           mod = ::Module.new do
-            methods.each { |method_name| Do.wrap_method(self, method_name, :public) }
+            public_methods.each do |method_name|
+              Do.wrap_method(self, method_name, nil)
+            end
+
+            methods_with_visibility.each do |visibility, methods|
+              methods.each do |method_name|
+                Do.wrap_method(self, method_name, visibility)
+              end
+            end
           end
 
           ::Module.new do

--- a/spec/integration/do_all_spec.rb
+++ b/spec/integration/do_all_spec.rb
@@ -4,6 +4,8 @@ require "dry/monads/result"
 require "dry/monads/do/all"
 
 RSpec.describe(Dry::Monads::Do::All) do
+  class VisibilityLeak < StandardError; end
+
   result_mixin = Dry::Monads::Result::Mixin
   include result_mixin
 
@@ -31,6 +33,33 @@ RSpec.describe(Dry::Monads::Do::All) do
         expect(adder.sum(1, 2) { |x| x }).to eql(Success(3))
       end
     end
+
+    context 'visibility protection' do
+      let(:object) do
+        spec = self
+        Class.new {
+          include spec.mixin
+
+          protected
+          def my_protected_method
+            raise VisibilityLeak, "Should not be able to call a protected method"
+          end
+
+          private
+          def my_private_method
+            raise VisibilityLeak, "Should not be able to call a private method"
+          end
+        }.tap {|c| c.include(result_mixin) }.new
+      end
+
+      it 'is preserved for protected methods' do
+        expect { object.my_protected_method }.to raise_error(NoMethodError)
+      end
+
+      it 'is preserved for private methods' do
+        expect { object.my_private_method }.to raise_error(NoMethodError)
+      end
+    end
   end
 
   context "Do::All" do
@@ -51,6 +80,36 @@ RSpec.describe(Dry::Monads::Do::All) do
       adder = klass.new
 
       expect(adder.sum(Success(1), Success(2))).to eql(Success(3))
+    end
+
+    it 'preserves private methods' do
+      klass = Class.new {
+        private
+        def my_private_method
+          raise VisibilityLeak, "Should not be able to call a private method"
+        end
+      }.tap { |c|
+        c.include(mixin, result_mixin)
+      }
+
+      object = klass.new
+
+      expect { object.my_private_method }.to raise_error(NoMethodError)
+    end
+
+    it 'preserves protected methods' do
+      klass = Class.new {
+        protected
+        def my_protected_method
+          raise VisibilityLeak, "Should not be able to call a protected method"
+        end
+      }.tap { |c|
+        c.include(mixin, result_mixin)
+      }
+
+      object = klass.new
+
+      expect { object.my_protected_method }.to raise_error(NoMethodError)
     end
 
     context "inheritance" do
@@ -78,6 +137,38 @@ RSpec.describe(Dry::Monads::Do::All) do
 
         expect(base.new.call).to eql(Success("success"))
         expect(child.new.call).to eql(Success("success"))
+      end
+
+      it 'preserves private methods' do
+        base = Class.new.tap { |c| c.include(mixin, result_mixin) }
+        klass = Class.new(base) {
+          private
+          def my_private_method
+            raise VisibilityLeak, "Should not be able to call a private method"
+          end
+        }.tap { |c|
+          c.include(mixin, result_mixin)
+        }
+
+        object = klass.new
+
+        expect { object.my_private_method }.to raise_error(NoMethodError)
+      end
+
+      it 'preserves protected methods' do
+        base = Class.new.tap { |c| c.include(mixin, result_mixin) }
+        klass = Class.new(base) {
+          protected
+          def my_protected_method
+            raise VisibilityLeak, "Should not be able to call a protected method"
+          end
+        }.tap { |c|
+          c.include(mixin, result_mixin)
+        }
+
+        object = klass.new
+
+        expect { object.my_protected_method }.to raise_error(NoMethodError)
       end
     end
 

--- a/spec/integration/do_for_spec.rb
+++ b/spec/integration/do_for_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "dry/monads/do"
+
+RSpec.describe(Dry::Monads::Do) do
+  result_mixin = Dry::Monads::Result::Mixin
+  include result_mixin
+
+  describe ".for" do
+    let(:input_value) { 10 }
+    let(:equation) do
+      klass = Class.new do
+        include Dry::Monads::Do.for(:answer, protected: [:square], private: [:double])
+
+        def initialize(starting_value)
+          @starting_value = starting_value
+        end
+
+        def answer
+          c = yield(square) + yield(double)
+          Success(c)
+        end
+
+        protected
+
+        def square
+          s = yield(starting_value) * yield(starting_value)
+          Success(s)
+        end
+
+        private
+
+        def double
+          d = yield(starting_value) + yield(starting_value)
+          Success(d)
+        end
+
+        attr_reader :starting_value
+      end
+      klass.tap { |c| c.include(result_mixin) }.new(Success(input_value))
+    end
+
+    it "can call a public method" do
+      expect { equation.answer }.to_not raise_error
+    end
+
+    it "works" do
+      expect(equation.answer).to eq(Success(120))
+    end
+
+    it "cannot call a protected method directly" do
+      expect { equation.square }.to raise_error(NoMethodError)
+    end
+
+    it "cannot call a private method directly" do
+      expect { equation.double }.to raise_error(NoMethodError)
+    end
+  end
+end


### PR DESCRIPTION
I rebased https://github.com/dry-rb/dry-monads/issues/128 to investigate further. (at this point) I disagree with changing `.for`'s interface so I'll probably revert it back.