### PR TITLE
Use throw instead of exceptions for control flow

### DIFF
--- a/lib/dry/monads/do.rb
+++ b/lib/dry/monads/do.rb
@@ -12,6 +12,8 @@ module Dry
     module Do
       extend Mixin
 
+      HALT_SIGNAL = :__dry_monads_do_halt__
+
       DELEGATE = ::RUBY_VERSION < "2.7" ? "*" : "..."
 
       VISIBILITY_WORD = {
@@ -19,18 +21,6 @@ module Dry
         private: "private ",
         protected: "protected "
       }
-
-      # @api private
-      class Halt < StandardError
-        # @api private
-        attr_reader :result
-
-        def initialize(result)
-          super()
-
-          @result = result
-        end
-      end
 
       # @api private
       class MethodTracker < ::Module
@@ -169,7 +159,7 @@ module Dry
 
         # @api private
         def halt(result)
-          raise Halt.new(result), "", []
+          throw(Do::HALT_SIGNAL, result)
         end
       end
     end

--- a/lib/dry/monads/do/mixin.rb
+++ b/lib/dry/monads/do/mixin.rb
@@ -37,9 +37,7 @@ module Dry
       module Mixin
         # @api public
         def call
-          yield
-        rescue Halt => e
-          e.result
+          catch(Do::HALT_SIGNAL) { return yield }
         end
 
         # @api public

--- a/spec/integration/do_spec.rb
+++ b/spec/integration/do_spec.rb
@@ -107,10 +107,11 @@ RSpec.describe(Dry::Monads::Do) do
           end
 
           def transaction
-            yield
-          rescue StandardError => e
+            error = catch(Dry::Monads::Do::HALT_SIGNAL) { return yield }
+
             @rolled_back = true
-            raise e
+
+            throw(Dry::Monads::Do::HALT_SIGNAL, error)
           end
         end
       end


### PR DESCRIPTION
Is there an reason to not sue `catch(...) { throw ... }` instead of { begin; raise ...; rescue ...; end`?