### PR TITLE
Store the monad that caused an UnwrapError

### DIFF
--- a/lib/dry/monads/errors.rb
+++ b/lib/dry/monads/errors.rb
@@ -6,9 +6,9 @@ module Dry
     class UnwrapError < StandardError
       attr_reader :source
 
-      def initialize(ctx)
-        @source = ctx
-        super("value! was called on #{ctx.inspect}")
+      def initialize(source)
+        @source = source
+        super("value! was called on #{source.inspect}")
       end
     end
 

--- a/lib/dry/monads/errors.rb
+++ b/lib/dry/monads/errors.rb
@@ -4,7 +4,10 @@ module Dry
   module Monads
     # An unsuccessful result of extracting a value from a monad.
     class UnwrapError < StandardError
+      attr_reader :source
+
       def initialize(ctx)
+        @source = ctx
         super("value! was called on #{ctx.inspect}")
       end
     end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -489,7 +489,11 @@ RSpec.describe(Dry::Monads::Result) do
 
     describe "#value!" do
       it "raises an error" do
-        expect { subject.value! }.to raise_error(Dry::Monads::UnwrapError, 'value! was called on Failure("bar")')
+        expect { subject.value! }.to(raise_error { |error|
+          expect(error).to be_a Dry::Monads::UnwrapError
+          expect(error.message).to match 'value! was called on Failure("bar")'
+          expect(error.source).to eq subject
+        })
       end
     end
 


### PR DESCRIPTION
Forcing the use of `yield` (which is in fact an implementation artifact) to write flowing method bodies is not always nice, because it requires a relatively high mental gymnastics.

With this change, we can have an alternative way that relies more on standard ruby constructs:

```rb
class SomeService
  # include Dry::Monads[:do] not needed anymore
  include Dry::Monads[:result]

  # Returns Failure(3.14)
  def call
    a = collaborator.call(**args).value!
    b = other_collaborator.call(**args).value!
 
    Success(a + b)
  rescue Dry::Monads::UnwrapError => exception
    exception.source
  end

  def collaborator
    ->(**) { Success(42) }
  end

  def other_collaborator
    ->(**) { Failure(3.14) }
  end
end
```

while with `do` it would be shorter but less ruby-like:

```rb
class SomeService
  include Dry::Monads[:do]
  include Dry::Monads[:result]

  # Returns Failure(3.14)
  def call
    a = yield collaborator.call(**args)
    b = yield other_collaborator.call(**args)
 
    Success(a + b)
  end

  def collaborator
    ->(**) { Success(42) }
  end

  def other_collaborator
    ->(**) { Failure(3.14) }
  end
end
```
