### PR TITLE
Add fold to allow mapping both success and failure types differently

### DIFF
--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -185,6 +185,14 @@ module Dry
           end
         end
 
+        # Maps both the success and failure types differently
+        # success will be invoked in case of Success
+        #
+        # @return [Object]
+        def fold(success, _failure)
+          success.call(@value)
+        end
+
         # Pattern matching
         #
         # @example
@@ -351,6 +359,14 @@ module Dry
         # @return [RightBiased::Left]
         def and(_)
           self
+        end
+
+        # Maps both the success and failure types differently
+        # failure will be invoked in case of Failure
+        #
+        # @return [Object]
+        def fold(_success, failure)
+          failure.call(@value)
         end
 
         # Pattern matching

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -311,6 +311,14 @@ RSpec.describe(Dry::Monads::Result) do
         expect(success["foo"].either(-> x { x + "foo" }, -> x { x + "bar" })).to eq("foofoo")
       end
     end
+
+    describe "#fold" do
+      it "invokes ok funciton" do
+        ok = ->(x) { "success #{x}" }
+        err = ->(x) { "failure #{x}" }
+        expect(success["foo"].fold(ok, err)).to eq("success foo")
+      end
+    end
   end
 
   describe result::Failure do
@@ -532,6 +540,14 @@ RSpec.describe(Dry::Monads::Result) do
     describe "#either" do
       it "returns second function applied to the value" do
         expect(failure["bar"].either(-> x { x + "foo" }, -> x { x + "bar" })).to eq("barbar")
+      end
+    end
+
+    describe "#fold" do
+      it "invokes err funciton" do
+        ok = ->(x) { "success #{x}" }
+        err = ->(x) { "failure #{x}" }
+        expect(failure["foo"].fold(ok, err)).to eq("failure foo")
       end
     end
   end


### PR DESCRIPTION
Add fold which will reduce success or failure into a final value.

It will take 2 proc, lambda or reference to function & will invoke the right function based on whether result is success or failure.

so instead of this

```ruby
result = Success({name: "foo"})
if result.success?
  result.success.to_json
else
  {error: result.failure}.to_json
end
```

we can make this

```ruby
result = Success({name: "foo"})
ok = ->(obj) { obj.to_json }
err = ->(msg) { { error: msg }.to_json }
result.fold(ok, err) # "{\"name\":\"foo\"}"
```