### PR TITLE
Ensure value isn't misinterpreted when raising InvalidFailureTypeError

### DIFF
--- a/lib/dry/monads/result/fixed.rb
+++ b/lib/dry/monads/result/fixed.rb
@@ -17,7 +17,7 @@ module Dry::Monads
             if error === value
               Failure.new(value, RightBiased::Left.trace_caller)
             else
-              raise InvalidFailureTypeError, value
+              raise InvalidFailureTypeError.new(value)
             end
           end
 

--- a/spec/integration/result_fixed_spec.rb
+++ b/spec/integration/result_fixed_spec.rb
@@ -45,6 +45,21 @@ RSpec.describe(Dry::Monads::Result) do
         expect { subject.Failure(runtime_error) }.to raise_error(Dry::Monads::InvalidFailureTypeError)
       end
     end
+
+    context "errors matching Kernel#raise keyword arguments" do
+      before do
+        module Test
+          class Operation
+            include Dry::Monads::Result(Types::Hash.schema(cause: Types::Symbol).strict)
+          end
+        end
+      end
+
+      it "raises the appropriate error on unexpected type" do
+        expect { subject.Failure({cause: "not a symbol"}) }
+          .to raise_error(Dry::Monads::InvalidFailureTypeError)
+      end
+    end
   end
 
   context "arbitrary objects" do


### PR DESCRIPTION
`Kernel#raise` can take `:cause` as a keyword argument. If `value`
happens to be a `Hash` containing the key `:cause` bad things happen.

See the following example:

```ruby
   raise InvalidFailureTypeError, { cause: :not_found, message: "Could not find user" }
   # => *** TypeError Exception: exception object expected
```
Ruby interprets `:cause` in the hash as a keyword argument and since `:cause` isn't an `Exception` object or `nil`, it generates a `TypeError`.

In the case of `InvalidFailureTypeError ` there's a slight variation that may occur:

```ruby
raise InvalidFailureTypeError, { cause: :not_found }
# => ArgumentError: wrong number of arguments (given 0, expected 1)
```

Ruby will delete the `:cause` from the provided hash since it interprets it as a keyword argument. The initialiser of `InvalidFailureTypeError` expects a message to be provided

https://github.com/dry-rb/dry-monads/blob/366cb114fad7daf5db9a6f75bb03812b89d35279/lib/dry/monads/errors.rb#L14

but since the hash is now empty, Ruby calls `InvalidFailureTypeError.new` without any arguments.