### PR TITLE
Store the result that caused the UnwrapError, like in Do::Halt

### DIFF
--- a/lib/dry/monads/errors.rb
+++ b/lib/dry/monads/errors.rb
@@ -4,8 +4,13 @@ module Dry
   module Monads
     # An unsuccessful result of extracting a value from a monad.
     class UnwrapError < StandardError
-      def initialize(ctx)
-        super("value! was called on #{ctx.inspect}")
+      # @api private
+      attr_reader :result
+
+      def initialize(result)
+        super("value! was called on #{result.inspect}")
+
+        @result = result
       end
     end
 

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -489,7 +489,11 @@ RSpec.describe(Dry::Monads::Result) do
 
     describe "#value!" do
       it "raises an error" do
-        expect { subject.value! }.to raise_error(Dry::Monads::UnwrapError, 'value! was called on Failure("bar")')
+        expect { subject.value! }.to(raise_error do |error|
+          expect(error).to be_a(Dry::Monads::UnwrapError)
+          expect(error.message).to eql('value! was called on Failure("bar")')
+          expect(error.result).to eql(subject)
+        end)
       end
     end
 


### PR DESCRIPTION
This PR is basically a copy of https://github.com/dry-rb/dry-monads/pull/138 but keeping the naming consistent with `Do::Halt` (https://github.com/dry-rb/dry-monads/blob/master/lib/dry/monads/do.rb#L24).

I find it handy, to have access to the result, in systems that only implement "happy path" and delegate all exception handling to an external component.