### PR TITLE
Remove Lazy#wait

### DIFF
--- a/lib/dry/monads/either.rb
+++ b/lib/dry/monads/either.rb
@@ -12,7 +12,7 @@ module Dry
     deprecate_constant :Either
 
     class Result
-      extend Dry::Core::Deprecations[:"dry-monads"]
+      extend ::Dry::Core::Deprecations[:"dry-monads"]
 
       deprecate :to_either, :to_result
 

--- a/lib/dry/monads/lazy.rb
+++ b/lib/dry/monads/lazy.rb
@@ -2,6 +2,7 @@
 
 require "concurrent/promise"
 
+require "dry/core/deprecations"
 require "dry/monads/task"
 
 module Dry
@@ -11,6 +12,8 @@ module Dry
     # computation is evaluated not more than once (compare with the built-in
     # lazy assignement ||= which does not guarantee this).
     class Lazy < Task
+      extend ::Dry::Core::Deprecations[:"dry-monads"]
+
       class << self
         # @private
         def new(promise = nil, &block)
@@ -40,6 +43,14 @@ module Dry
         @promise.execute
         self
       end
+
+      # @return [Boolean]
+      def evaluated?
+        @promise.complete?
+      end
+      deprecate :complete?, :evaluated?
+
+      undef_method :wait
 
       # @return [String]
       def to_s

--- a/spec/unit/lazy_spec.rb
+++ b/spec/unit/lazy_spec.rb
@@ -83,4 +83,10 @@ RSpec.describe(Dry::Monads::Lazy) do
       expect(Lazy { 1 }.discard.value!).to be mixin::Unit
     end
   end
+
+  describe "#evaluated?" do
+    it "checks if the value is computed" do
+      expect(subject.evaluated?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Lazy is a subclass of Task but they actually share nothing in common so methods from Task shouldn't leak to Lazy