### PR TITLE
Add Result#alt_map

### DIFF
--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -148,6 +148,13 @@ module Dry
         def flip
           Failure.new(@value, RightBiased::Left.trace_caller)
         end
+
+        # Ignores values and returns self, see {Failure#alt_map}
+        #
+        # @return [Result::Success]
+        def alt_map(_ = nil)
+          self
+        end
       end
 
       # Represents a value of a failed operation.
@@ -290,6 +297,21 @@ module Dry
         # @return [Any] Return value of `g`
         def either(_, g)
           g.(failure)
+        end
+
+        # Lifts a block/proc over Failure
+        #
+        # @overload alt_map(proc)
+        #   @param proc [#call]
+        #   @return [Result::Failure]
+        #
+        # @overload alt_map
+        #   @param block [Proc]
+        #   @return [Result::Failure]
+        #
+        def alt_map(proc = Undefined, &block)
+          f = Undefined.default(proc, block)
+          self.class.new(f.(failure), RightBiased::Left.trace_caller)
         end
       end
 

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -313,6 +313,17 @@ RSpec.describe(Dry::Monads::Result) do
         expect(success["foo"].either(-> x { "#{x}foo" }, -> x { "#{x}bar" })).to eq("foofoo")
       end
     end
+
+    describe "#alt_map" do
+      it "is a no-op" do
+        expect(success.("foo").alt_map { raise }).to eql(
+          success.("foo")
+        )
+        expect(success.("foo").alt_map(proc { raise })).to eql(
+          success.("foo")
+        )
+      end
+    end
   end
 
   describe result::Failure do
@@ -575,6 +586,17 @@ RSpec.describe(Dry::Monads::Result) do
 
       it "tracks the caller" do
         expect(subject.Failure("fail").trace).to include("spec/unit/result_spec.rb")
+      end
+    end
+
+    describe "#alt_map" do
+      it "map over the failure value" do
+        expect(failure.("foo").alt_map(&:upcase)).to eql(
+          failure.("FOO")
+        )
+        expect(subject.Failure("foo").alt_map(:upcase.to_proc)).to eql(
+          failure.("FOO")
+        )
       end
     end
   end


### PR DESCRIPTION
It's dual to `Result#map`, it's a functor for the other type parameter.