### PR TITLE
Add Try#handle

### DIFF
--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -168,6 +168,15 @@ module Dry
           end
         end
         alias_method :inspect, :to_s
+
+        # Ignores values and returns self, see {Error#handle}
+        #
+        # @param errors [Class] List of Exception subclasses
+        #
+        # @return [Try::Value]
+        def handle(*_errors)
+          self
+        end
       end
 
       # Represents a result of a failed execution.
@@ -214,6 +223,26 @@ module Dry
         # @return [Boolean]
         def ===(other)
           Error === other && exception === other.exception
+        end
+
+        # Acts in a similar way to `rescue`. It checks if
+        # {exception} is one of {errors} and yields the block if so.
+        #
+        # @param errors [Class] List of Exception subclasses
+        #
+        # @return [Try::Value]
+        def handle(*errors)
+          if errors.empty?
+            classes = DEFAULT_EXCEPTIONS
+          else
+            classes = errors
+          end
+
+          if classes.any? { |c| c === exception }
+            Value.new([exception.class], yield(exception))
+          else
+            self
+          end
         end
       end
 

--- a/spec/unit/try_spec.rb
+++ b/spec/unit/try_spec.rb
@@ -196,6 +196,12 @@ RSpec.describe(Dry::Monads::Try) do
       end
     end
     # rubocop:enable Style/CaseEquality
+
+    describe "#handle" do
+      it "is a no-op for Value" do
+        expect(subject.handle(ZeroDivisionError) { raise }).to be(subject)
+      end
+    end
   end
 
   describe(try::Error) do
@@ -315,6 +321,15 @@ RSpec.describe(Dry::Monads::Try) do
       end
     end
     # rubocop:enable Style/CaseEquality
+
+    describe "#handle" do
+      it "works similar to rescuer" do
+        expect(subject.handle(ZeroDivisionError) { 999 }).to eql(value[[ZeroDivisionError], 999])
+        expect(subject.handle(StandardError) { 888 }).to eql(value[[ZeroDivisionError], 888])
+        expect(subject.handle { 777 }).to eql(value[[ZeroDivisionError], 777])
+        expect(subject.handle(ArgumentError)).to be(subject)
+      end
+    end
   end
 
   describe try::Mixin do


### PR DESCRIPTION
It works similar to how `rescue` does:

```ruby
extend Dry::Monads[:try]

error = Try { 1 / 0 }
error.handle(ZeroDivisionError) { 99 } # => Try::Value(99)
```