### PR TITLE
Deprecate mapping nil to None inside Some#fmap

### DIFF
--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe(Dry::Monads::Maybe) do
     end
 
     describe "#maybe" do
-      it "is an alias for fmap" do
-        expect(subject.method(:maybe)).to eql(subject.method(:fmap))
+      it "maps nil values returned from block to None" do
+        expect(subject.maybe { nil }).to eql(none)
       end
     end
 


### PR DESCRIPTION
This seems like a big shift but it's unavoidable. Current behavior violates monad laws and hence has to be corrected. We have Maybe#maybe as a drop-in replacement so fixing won't be too hard.

Reasons:

```ruby
extend Dry::Monads[:maybe]

Some(1).fmap { nil }.fmap { 1 }
# => None
# but it must be the same as
Some(1).fmap { nil; 1 }
# => Some(1)
```

In 2.0 it won't be like that (mostly because I've no clue how to do it), instead, `fmap { nil }` will raise an error.

Context: https://www.reddit.com/r/ruby/comments/8tyt96/dryrb_drymonads_10_released/e1br5x5