### PR TITLE
Add Maybe#filter

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -153,6 +153,25 @@ module Dry
           Maybe.coerce(bind(*args, &block))
         end
 
+        # Accepts a block and runs it against the wrapped value.
+        # If the block returns a trurhy value the result is self,
+        # otherwise None. If no block is given, the value serves
+        # and its result.
+        #
+        # @param with [#call] positional block
+        # @param block [Proc] block
+        #
+        # @return [Maybe::None, Maybe::Some]
+        def filter(with = Undefined, &block)
+          block = Undefined.default(with, block || IDENTITY)
+
+          if block.(@value)
+            self
+          else
+            Monads::None()
+          end
+        end
+
         # @return [String]
         def to_s
           if Unit.equal?(@value)
@@ -258,6 +277,13 @@ module Dry
         # @api private
         def deconstruct
           EMPTY_ARRAY
+        end
+
+        # @see Maybe::Some#filter
+        #
+        # @return [Maybe::None]
+        def filter(_ = Undefined)
+          self
         end
       end
 

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -268,6 +268,15 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(some["foo"].and(none)).to eql(none)
       end
     end
+
+    describe "#filter" do
+      it "returns None when block evaluates to false" do
+        expect(some[4].filter(&:odd?)).to eql(none)
+        expect(some[3].filter(&:odd?)).to eql(some[3])
+        expect(some[4].filter(:odd?.to_proc)).to eql(none)
+        expect(some[3].filter(:odd?.to_proc)).to eql(some[3])
+      end
+    end
   end
 
   describe maybe::None do
@@ -482,6 +491,14 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(none.and(some["foo"]) { raise }).to eql(none)
         expect(none.and(some["foo"])).to eql(none)
         expect(none.and(none)).to eql(none)
+      end
+    end
+
+    describe "#filter" do
+      it "always returns self" do
+        expect(none.filter(&:odd?)).to eql(none)
+        expect(none.filter(:odd?.to_proc)).to eql(none)
+        expect(none.filter).to eql(none)
       end
     end
   end


### PR DESCRIPTION
Maybe can cat as a 1-sized array. Better see examples:

```ruby
extend Dry::Monads[:maybe]

Some(5).filter { _1.odd? } # => Some(5)
Some(5).filter { _1.even? } # => None
Some(4 == 5).filter # => None
None.filter { _1.odd? } # => None
```

This function can be useful, occasionally.