### PR TITLE
Add RightBiased#|

### DIFF
--- a/lib/dry/monads/right_biased.rb
+++ b/lib/dry/monads/right_biased.rb
@@ -12,7 +12,7 @@ module Dry
       # Right part
       #
       # @api public
-      module Right
+      module Right # rubocop:disable Metrics/ModuleLength
         # @private
         def self.included(m)
           super
@@ -87,6 +87,16 @@ module Dry
         #
         # @return [RightBiased::Right]
         def or(*)
+          self
+        end
+
+        # Ignores arguments and returns self. It exists to keep the interface
+        # identical to that of {RightBiased::Left}.
+        #
+        # @param _alt [RightBiased::Right, RightBiased::Left]
+        #
+        # @return [RightBiased::Right]
+        def |(_alt)
           self
         end
 
@@ -297,6 +307,15 @@ module Dry
         # @return [Object]
         def or(*)
           raise NotImplementedError
+        end
+
+        # Returns the passed value. Works in pair with {RightBiased::Right#|}.
+        #
+        # @param alt [RightBiased::Right, RightBiased::Left]
+        #
+        # @return [RightBiased::Right, RightBiased::Left]
+        def |(alt)
+          self.or(alt)
         end
 
         # A lifted version of `#or`. This is basically `#or` + `#fmap`.

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -501,6 +501,14 @@ RSpec.describe(Dry::Monads::Maybe) do
         expect(none.filter).to eql(none)
       end
     end
+
+    describe "#|" do
+      it "chooses the right value" do
+        expect(none | none | some[3]).to eql(some[3])
+        expect(none | some[3] | none | some[3]).to eql(some[3])
+        expect(none | none | none).to eql(none)
+      end
+    end
   end
 
   describe maybe::Mixin do

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -599,5 +599,13 @@ RSpec.describe(Dry::Monads::Result) do
         )
       end
     end
+
+    describe "#|" do
+      it "chooses the right value" do
+        expect(failure.("foo") | failure.("bar") | success.("baz")).to eql(success.("baz"))
+        expect(failure.("foo") | failure.("bar") | failure.("baz")).to eql(failure.("baz"))
+        expect(success.("baz") | failure.("foo") | failure.("bar")).to eql(success.("baz"))
+      end
+    end
   end
 end


### PR DESCRIPTION
It's an alias for `.or`

```ruby
extend Dry::Monads[:result, :maybe]

Some(1) | None() # => Some(1)
Some(1) | None() | Some(2) # => Some(1)
None() | Some(1) | Some(2) # => Some(1)

Failure(:not_found) | Success(1) | Success(2) # => Success(1)
```