### PR TITLE
Add on_success and on_failure callbacks to Result

### DIFF
--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -155,6 +155,28 @@ module Dry
         def alt_map(_ = nil)
           self
         end
+
+        # Runs a callback if the result is a Success.
+        #
+        # @example
+        #   Dry::Monads.Success("Yay!")
+        #     .on_failure { raise "This won't run" }
+        #     .on_success { |result| puts result.value! } # => Success("Yay!")
+        #   # prints "Yay!"
+        #
+        # @return [Result::Success]
+        def on_success
+          yield(self) if block_given?
+
+          self
+        end
+
+        # Ignores the given block and returns self, see {Failure#on_failure}
+        #
+        # @return [Result::Success]
+        def on_failure(&_block)
+          self
+        end
       end
 
       # Represents a value of a failed operation.
@@ -312,6 +334,28 @@ module Dry
         def alt_map(proc = Undefined, &block)
           f = Undefined.default(proc, block)
           self.class.new(f.(failure), RightBiased::Left.trace_caller)
+        end
+
+        # Ignores the given block and returns self, see {Success#on_success}
+        #
+        # @return [Result::Failure]
+        def on_success(&_block)
+          self
+        end
+
+        # Runs a callback if the result is a Failure.
+        #
+        # @example
+        #   Dry::Monads.Failure("Whoops!")
+        #     .on_success { raise "This won't run" }
+        #     .on_failure { |result| puts result.value! } # => Failure("Whoops!")
+        #   # prints "Whoops!"
+        #
+        # @return [Result::Failure]
+        def on_failure
+          yield(self) if block_given?
+
+          self
         end
       end
 

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -324,6 +324,27 @@ RSpec.describe(Dry::Monads::Result) do
         )
       end
     end
+
+    describe "#on_success" do
+      it "returns the original result" do
+        expect(success[123].on_success { failure["foo"] }).to eql(success[123])
+      end
+
+      it "yields itself to a block" do
+        count = 0
+        success[123].on_success { |r| count += r.success }
+
+        expect(count).to eql(123)
+      end
+    end
+
+    describe "#on_failure" do
+      it "always return itself" do
+        expect(success[123].on_failure { failure["foo"] }).to eql(success[123])
+        expect(success[123].on_failure { raise }).to eql(success[123])
+        expect(success[123].on_failure).to eql(success[123])
+      end
+    end
   end
 
   describe result::Failure do
@@ -542,6 +563,27 @@ RSpec.describe(Dry::Monads::Result) do
         expect(failure[123].and(success["foo"]) { raise }).to eql(failure[123])
         expect(failure[123].and(success["foo"])).to eql(failure[123])
         expect(failure[123].and(failure["foo"])).to eql(failure[123])
+      end
+    end
+
+    describe "#on_success" do
+      it "always return itself" do
+        expect(failure[123].on_success { success["foo"] }).to eql(failure[123])
+        expect(failure[123].on_success { raise }).to eql(failure[123])
+        expect(failure[123].on_success).to eql(failure[123])
+      end
+    end
+
+    describe "#on_failure" do
+      it "returns the original result" do
+        expect(failure[123].on_failure { success["foo"] }).to eql(failure[123])
+      end
+
+      it "yields itself to a block" do
+        count = 0
+        failure[123].on_failure { |r| count += r.failure }
+
+        expect(count).to eql(123)
       end
     end
 


### PR DESCRIPTION
Ruby has the `Object#tap` to perform some "side actions" outside the "main path" of the code. This introduces something similar, but for Result. It adds two callbacks, `on_success` and `on_failure`. This helps keep the method chains since it avoids needing to add `if` expressions and explicitly returning the original monad again.

Ex:

```ruby
def fetch_repositories
  with_loading_spinner("Fetching repositories...") do |spinner|
    Repository
      .fetch(language: "ruby") # Returns a Result
      .on_success { spinner.success }
      .on_failure { spinner.error }
  end
end

# vs

def fetch_repositories
  with_loading_spinner("Fetching repositories...") do |spinner|
    result = Repository.fetch(language: "ruby")
    spinner.success if result.success?
    spinner.error if result.failure?

    result
  end
end
```

I'd love to make this more generic and add it to `RightBiased` so we could use it on Maybe and Try as well, but I wasn't sure about the naming.

To me, this looks a bit like `Object#tap`, so `tap_left` and `tap_right` would be options, but it feels a bit weird (too low level, maybe?). Another option would be to reference `Result#either`, but I don't like requiring **both** left and callbacks simultaneously.

```ruby
def fetch_repositories
  with_loading_spinner("Fetching repositories...") do |spinner|
    Repository
      .fetch(language: "ruby") # Returns a Result
      .tap_either(
        ->(_success_result) { spinner.success },
        ->(_failure_result) { spinner.failure }, 
      ) # what if I just wanted one of these?
  end
end
```

I'm happy to change the API with any new idea. Also, LMK if there's a better way to handle this with the current API.