### PR TITLE
[docsite] Break up first Maybe() example into three lines

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -63,7 +63,10 @@ user_state = state_name || "No state"
 By using the `Maybe` monad you can preserve the structure of this code at a cost of introducing a notion of `nil`-able result:
 
 ```ruby
-state_name = Maybe(User.find_by(id: params[:id])).maybe(&:address).maybe(&:city).maybe(&:state).maybe(&:name)
+state_name = Maybe(
+  User.find_by(id: params[:id])
+).maybe(&:address).maybe(&:city).maybe(&:state).maybe(&:name)
+
 user_state = state_name.value_or("No state")
 ```
 


### PR DESCRIPTION
On medium (laptop-sized) screens, these lines break in a way that's hard to read. Since this is likely the very first time readers are seeing dry-monads in action, we should take particular attention to showing that the code is _more_ readable and elegant than the procedural option shown before it.

The reason this happens is that the only space in the line is after the `id:`. 

Before this PR:
<img width="651" alt="image" src="https://user-images.githubusercontent.com/632942/149961716-19a2aa60-956b-47e4-bb2e-37b942de5702.png">


After this PR:
<img width="582" alt="image" src="https://user-images.githubusercontent.com/632942/149961067-de72fe57-b88d-44e5-ac20-47d93221b727.png">


On tiny (phone) screens, this long line of `.maybe(&:method)`s still breaks in a weird way. We could 'fix' that by putting each `.maybe()` on its own line and I'd be happy to do that, but we should do that uniformly across the docsite (all of the dry-rb docsites, ideally 😬 ) rather than just this one.