### PR TITLE
Fixed typo in do-notation site docs

### DIFF
--- a/docsite/source/do-notation.html.md
+++ b/docsite/source/do-notation.html.md
@@ -174,7 +174,7 @@ require 'dry/monads/do'
 require 'dry/monads/result'
 
 # some random place in your code
-Dry::Monads.Do.() do
+Dry::Monads::Do.() do
   user = Dry::Monads::Do.bind create_user
   account = Dry::Monads::Do.bind create_account(user)
 


### PR DESCRIPTION
Simple change, fixed a typo on `Dry::Monads::Do` method notation on the docs.