### PR TITLE
Update checkout action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       COVERAGE_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install package dependencies
         run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
       - name: Set up Ruby
@@ -57,13 +57,13 @@ jobs:
       GITHUB_LOGIN: dry-bot
       GITHUB_TOKEN: ${{secrets.GH_PAT}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install package dependencies
         run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: "3.0"
       - name: Install dependencies
         run: gem install ossy --no-document
       - name: Trigger release workflow

--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -16,7 +16,7 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: |

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -28,7 +28,7 @@ jobs:
         type: ["Style", "Layout", "Naming", "Lint", "Metrics", "Security"]
     steps:
     - name: Clone
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Get git diff
       id: get_diff
       uses: technote-space/get-diff-action@v4

--- a/.github/workflows/sync_configs.yml
+++ b/.github/workflows/sync_configs.yml
@@ -17,9 +17,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout ${{github.repository}}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout devtools
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: dry-rb/devtools
           path: tmp/devtools


### PR DESCRIPTION
This resolves Node 12 warnings that are showing up in the actions.