### PR TITLE
Fix bin/console script

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -6,40 +6,5 @@ require "dry/monads/all"
 
 M = Dry::Monads
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-require "pry"
-
-class Foo
-  include Dry::Monads[:result, :do]
-
-  def self.unwrap(method_name)
-    meth = instance_method(method_name)
-    undef_method(method_name)
-
-    define_method(method_name) do |value|
-      meth.bind_call(self, **value)
-    end
-  end
-
-  def first(a)
-    Success(x: a)
-  end
-
-  unwrap \
-    def second(x:) # rubocop:disable Lint/UnusedMethodArgument
-    Success(:anything)
-  end
-
-  def call(a)
-    first(a).bind(&method(:second))
-  end
-end
-
-obj = Foo.new
-
-binding.pry
-
-p
+require "irb"
+IRB.start(__FILE__)


### PR DESCRIPTION
- Avoid error when trying to run `binding.pry`, as `pry-byebug` is not part of the bundle.
- Remove code probably used for debugging at some point.
- Depend on standard `irb`.
