### PR TITLE
Alias @value to @exception in Try::Error

### DIFF
--- a/lib/dry/monads/try.rb
+++ b/lib/dry/monads/try.rb
@@ -186,7 +186,7 @@ module Dry
         def initialize(exception)
           super()
 
-          @exception = exception
+          @exception = @value = exception
         end
 
         # @return [String]


### PR DESCRIPTION
This allows deconstruct to work correctly

Fixes: #176 