### PR TITLE
Suppress warnings about ignored blocks from do/all (fix #179)

### DIFF
--- a/lib/dry/monads/do/all.rb
+++ b/lib/dry/monads/do/all.rb
@@ -153,5 +153,18 @@ module Dry
 
     require "dry/monads/registry"
     register_mixin(:do, Do::All)
+
+    if ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("3.4.0")
+      ::Warning.prepend(Module.new {
+        def warn(message)
+          if message.include?("dry-monads/lib/dry/monads/do.rb") &&
+            message.include?("warning: the block passed to")
+            nil
+          else
+            super
+          end
+        end
+      })
+    end
   end
 end

--- a/spec/integration/do_all_spec.rb
+++ b/spec/integration/do_all_spec.rb
@@ -230,6 +230,22 @@ RSpec.describe(Dry::Monads::Do::All) do
         end
       end
     end
+
+    context "warnings" do
+      let(:klass) do
+        Class.new do
+          include Dry::Monads[:do, :result]
+
+          def without
+            Success()
+          end
+        end
+      end
+
+      it "doesn't produce warnings in methods what don't yield block" do
+        expect { klass.new.without }.to_not output.to_stderr
+      end
+    end
   end
 
   context "Do" do


### PR DESCRIPTION
Addresses https://github.com/dry-rb/dry-monads/issues/179. Although these warnings are generally useful, there's no reliable way to avoid them when using `include Dry::Monads[:do]`. My current approach is silencing them.