### PR TITLE
super_diff extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ end
 group :test do
   gem "debug_inspector"
   gem "dry-types"
+  gem "super_diff"
 end

--- a/lib/dry/monads/extensions.rb
+++ b/lib/dry/monads/extensions.rb
@@ -5,3 +5,7 @@ Dry::Monads.extend(Dry::Core::Extensions)
 Dry::Monads.register_extension(:rspec) do
   require "dry/monads/extensions/rspec"
 end
+
+Dry::Monads.register_extension(:super_diff) do
+  require "dry/monads/extensions/super_diff"
+end

--- a/lib/dry/monads/extensions/rspec.rb
+++ b/lib/dry/monads/extensions/rspec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rspec/matchers"
+
 debug_inspector_available =
   begin
     require "debug_inspector"

--- a/lib/dry/monads/extensions/super_diff.rb
+++ b/lib/dry/monads/extensions/super_diff.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "super_diff"
+require "super_diff/rspec"
+
+if Gem::Version.new("0.15.0") > SuperDiff::VERSION
+  raise "SuperDiff version must be >= 0.15.0"
+end
+
+module Dry
+  module Monads
+    module SuperDiff
+      VALUES = [
+        Result::Success,
+        Result::Failure,
+        Maybe::Some,
+        Maybe::None,
+        Try::Value
+      ].freeze
+
+      EXTRACT_VALUE = {
+        Result::Success => lambda(&:value!),
+        Result::Failure => lambda(&:failure),
+        Maybe::Some => lambda(&:value!),
+        Maybe::None => lambda { |_| Unit },
+        Try::Value => lambda(&:value!)
+      }.freeze
+
+      TOKEN_MAP = {
+        Result::Success => "Success(",
+        Result::Failure => "Failure(",
+        Maybe::Some => "Some(",
+        Maybe::None => "None(",
+        Try::Value => "Value("
+      }.freeze
+
+      module OperationTreeFlatteners
+        class MonadicValues < ::SuperDiff::Basic::OperationTreeFlatteners::CustomObject
+          def open_token
+            TOKEN_MAP[operation_tree.underlying_object.class]
+          end
+
+          def close_token = ")"
+
+          def item_prefix_for(_) = ""
+        end
+      end
+
+      module OperationTrees
+        class MonadicValues < ::SuperDiff::Basic::OperationTrees::CustomObject
+          def operation_tree_flattener_class
+            OperationTreeFlatteners::MonadicValues
+          end
+        end
+      end
+
+      module OperationTreeBuilders
+        class MonadicValues < ::SuperDiff::Basic::OperationTreeBuilders::CustomObject
+          def self.applies_to?(expected, actual)
+            VALUES.include?(expected.class) &&
+              actual.instance_of?(expected.class)
+          end
+
+          protected
+
+          def build_operation_tree
+            OperationTrees::MonadicValues.new([], underlying_object: actual)
+          end
+
+          def attribute_names
+            [:value]
+          end
+
+          private
+
+          def establish_expected_and_actual_attributes
+            @expected_attributes = get_value(expected)
+            @actual_attributes = get_value(actual)
+          end
+
+          def get_value(object)
+            v = EXTRACT_VALUE[object.class].(object)
+
+            if Unit.equal?(v)
+              EMPTY_HASH
+            else
+              {value: v}
+            end
+          end
+        end
+      end
+
+      module Differs
+        class MonadicValues < ::SuperDiff::Basic::Differs::CustomObject
+          def self.applies_to?(expected, actual)
+            VALUES.include?(expected.class) &&
+              expected.instance_of?(actual.class)
+          end
+
+          def operation_tree_builder_class
+            OperationTreeBuilders::MonadicValues
+          end
+        end
+      end
+
+      module InspectionTreeBuilders
+        class MonadicValues < ::SuperDiff::Basic::InspectionTreeBuilders::CustomObject
+          def self.applies_to?(object)
+            VALUES.include?(object.class)
+          end
+
+          def call
+            ::SuperDiff::Core::InspectionTree.new do |t1|
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text(TOKEN_MAP[object.class])
+
+                v = EXTRACT_VALUE[object.class].(object)
+
+                unless Unit.equal?(v)
+                  t2.nested do |t3|
+                    t3.add_inspection_of v
+                  end
+                end
+                t2.add_text(")")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+SuperDiff.configuration.tap do |config|
+  config.prepend_extra_differ_classes(Dry::Monads::SuperDiff::Differs::MonadicValues)
+  config.prepend_extra_inspection_tree_builder_classes(
+    Dry::Monads::SuperDiff::InspectionTreeBuilders::MonadicValues
+  )
+end

--- a/spec/extensions/super_diff_spec.rb
+++ b/spec/extensions/super_diff_spec.rb
@@ -1,0 +1,339 @@
+# frozen_string_literal: true
+
+require "super_diff"
+
+RSpec.describe "SuperDiff extension" do
+  let(:output_start_marker) do
+    /(expected:)|(Expected )/
+  end
+
+  let(:output_end_marker) do
+    /#{output_start_marker.source}|Finished/
+  end
+
+  def run_spec(code)
+    temp_spec = Tempfile.new(["failing_spec", ".rb"])
+    temp_spec.write(<<~RUBY)
+      require "dry/monads"
+
+      RSpec.describe "A failing example" do
+        include Dry::Monads::Result::Mixin
+        include Dry::Monads::Maybe::Mixin
+        include Dry::Monads::Try::Mixin
+
+        before(:all) do
+          Dry::Monads.load_extensions(:super_diff)
+        end
+
+        it "fails with a diff" do
+          #{code}
+        end
+      end
+    RUBY
+    temp_spec.close
+
+    process_output(`rspec --no-color #{temp_spec.path}`, temp_spec.path)
+  end
+
+  def process_output(output, path)
+    uncolored = output.gsub(/\e\[([;\d]+)?m/, "")
+    # cut out significant lines
+    lines = extract_diff(uncolored, path)
+    prefix = lines.filter_map { |line|
+      line.match(/^\A(\s+)/).to_s unless line.strip.empty?
+    }.min
+    processed_lines = lines.map { |line| line.gsub(prefix, "") }
+    remove_banner(processed_lines).join.gsub("\n\n\n", "\n\n").gsub(/\n\n\z/, "\n")
+  end
+
+  # remove this part from the output:
+  #
+  # Diff:
+  #
+  # ┌ (Key) ──────────────────────────┐
+  # │ ‹-› in expected, not in actual  │
+  # │ ‹+› in actual, not in expected  │
+  # │ ‹ › in both expected and actual │
+  # └─────────────────────────────────┘
+  #
+  def remove_banner(lines)
+    before_banner = lines.take_while { |line| !line.start_with?("Diff:") }
+    after_banner = lines.drop_while { |line|
+      !line.include?("└")
+    }.drop(1)
+    before_banner + after_banner
+  end
+
+  def extract_diff(output, path)
+    output.lines.drop_while { |line|
+      !line[output_start_marker]
+    }.take_while.with_index { |line, idx|
+      idx.zero? || !(line.include?(path) || line[output_start_marker])
+    }
+  end
+
+  context "Result" do
+    context "Success" do
+      context "eql?" do
+        example "with values on both sides" do
+          output = run_spec(<<~RUBY)
+            expect(Success(1)).to eql(Success(2))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: Success(2)
+                 got: Success(1)
+
+            (compared using eql?)
+
+              Success(
+            -   2
+            +   1
+              )
+          DIFF
+        end
+
+        example "hash" do
+          output = run_spec(<<~RUBY)
+            expect(
+              Success(a: 1, b: 2)
+            ).to eql(Success(a: 2, c: 2))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: Success({ a: 2, c: 2 })
+                 got: Success({ a: 1, b: 2 })
+
+            (compared using eql?)
+
+              Success(
+                {
+            -     a: 2,
+            +     a: 1,
+            -     c: 2
+            +     b: 2
+                }
+              )
+          DIFF
+        end
+
+        example "with value on expected side" do
+          output = run_spec(<<~RUBY)
+            expect(Success()).to eql(Success(1))
+          RUBY
+
+          expect(output).to include(<<~DIFF)
+            expected: Success(1)
+                 got: Success()
+
+            (compared using eql?)
+
+              Success(
+            -   1
+              )
+          DIFF
+        end
+
+        example "with value on actual side" do
+          output = run_spec(<<~RUBY)
+            expect(Success(1)).to eql(Success())
+          RUBY
+
+          expect(output).to include(<<~DIFF)
+            expected: Success()
+                 got: Success(1)
+
+            (compared using eql?)
+
+              Success(
+            +   1
+              )
+          DIFF
+        end
+      end
+
+      context "==" do
+        example "with values on both sides" do
+          output = run_spec(<<~RUBY)
+            expect(Success(1)).to eq(Success(2))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            Expected Success(1) to eq Success(2).
+
+              Success(
+            -   2
+            +   1
+              )
+          DIFF
+        end
+
+        example "with value on expected side" do
+          output = run_spec(<<~RUBY)
+            expect(Success()).to eq(Success(1))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            Expected Success() to eq Success(1).
+
+              Success(
+            -   1
+              )
+          DIFF
+        end
+
+        example "with value on actual side" do
+          output = run_spec(<<~RUBY)
+            expect(Success(1)).to eq(Success())
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            Expected Success(1) to eq Success().
+
+              Success(
+            +   1
+              )
+          DIFF
+        end
+      end
+    end
+
+    context "Failure" do
+      context "eql?" do
+        example "with values on both sides" do
+          output = run_spec(<<~RUBY)
+            expect(Failure(1)).to eql(Failure(2))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: Failure(2)
+                 got: Failure(1)
+
+            (compared using eql?)
+
+              Failure(
+            -   2
+            +   1
+              )
+          DIFF
+        end
+
+        example "with value on expected side" do
+          output = run_spec(<<~RUBY)
+            expect(Failure()).to eql(Failure(1))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: Failure(1)
+                 got: Failure()
+
+            (compared using eql?)
+
+              Failure(
+            -   1
+              )
+          DIFF
+        end
+
+        example "with arrays" do
+          output = run_spec(<<~RUBY)
+            expect(Failure([:error, :a])).to eql(Failure([:error, :b]))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: Failure([:error, :b])
+                 got: Failure([:error, :a])
+
+            (compared using eql?)
+
+              Failure(
+                [
+                  :error,
+            -     :b
+            +     :a
+                ]
+              )
+          DIFF
+        end
+      end
+    end
+  end
+
+  context "Maybe" do
+    context "Some" do
+      context "eql?" do
+        example "with values on both sides" do
+          output = run_spec(<<~RUBY)
+            expect(Some(1)).to eql(Some(2))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: Some(2)
+                 got: Some(1)
+
+            (compared using eql?)
+
+              Some(
+            -   2
+            +   1
+              )
+          DIFF
+        end
+
+        example "with None on expected side" do
+          output = run_spec(<<~RUBY)
+            expect(Some(1)).to eql(None())
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: None()
+                 got: Some(1)
+
+            (compared using eql?)
+          DIFF
+        end
+      end
+
+      context "==" do
+        example "with values on both sides" do
+          output = run_spec(<<~RUBY)
+            expect(Some(1)).to eq(Some(2))
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            Expected Some(1) to eq Some(2).
+
+              Some(
+            -   2
+            +   1
+              )
+          DIFF
+        end
+      end
+    end
+  end
+
+  context "Try" do
+    context "Value" do
+      context "eql?" do
+        example "with values on both sides" do
+          output = run_spec(<<~RUBY)
+            expect(Try { 1 }).to eql(Try { 2 })
+          RUBY
+
+          expect(output).to eql(<<~DIFF)
+            expected: Value(2)
+                 got: Value(1)
+
+            (compared using eql?)
+
+              Value(
+            -   2
+            +   1
+              )
+          DIFF
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ require "dry/monads/all"
 
 Dir["./spec/shared/**/*.rb"].each { |f| require f }
 
+Warning.ignore(/rspec-expectations/)
+Warning.ignore(/super_diff/)
 Warning.process { raise _1 }
 
 module Kernel


### PR DESCRIPTION
This adds targeted support for super_diff. [super_diff](https://github.com/splitwise/super_diff/) is a very useful gem for diffing expectations in rspec specs. This PR integrates dry-monads with super_diff in a nice way:

Before:
```ruby
     Failure/Error: expect(Success(1)).to eql(Success(2))

       expected: #<Dry::Monads::Result::Success:0x000000013a2d2068 @value=2>
            got: #<Dry::Monads::Result::Success:0x000000013a2d2270 @value=1>

       (compared using eql?)

       Diff:

         #<Dry::Monads::Result::Success:0x000000013a2d2270 {
       -   @value=2
       +   @value=1
         }>
```

After:
```ruby
     Failure/Error: expect(Success(1)).to eql(Success(2))

       expected: Success(2)
            got: Success(1)

       (compared using eql?)

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         Success(
       -   2
       +   1
         )
```

For activating the extension you'll need `super_diff`

`Gemfile`

```ruby
group :test do
  gem 'super_diff'
end
```

`spec_helper.rb`

```ruby
require 'dry/monads'

Dry::Monads.load_extensions(:super_diff)
```

I'll merge the PR and test this extension on my projects to see if corner cases are left.