### PR TITLE
Add pretty_print methods to Result and Maybe

### DIFF
--- a/lib/dry/monads/maybe.rb
+++ b/lib/dry/monads/maybe.rb
@@ -169,6 +169,17 @@ module Dry
           end
         end
         alias_method :inspect, :to_s
+
+        def pretty_print(pp)
+          pp.text "Some("
+          unless Unit.equal?(@value)
+            pp.group(1) do
+              pp.breakable("")
+              pp.pp(@value)
+            end
+          end
+          pp.text ")"
+        end
       end
 
       # Represents an absence of a value, i.e. the value nil.
@@ -237,6 +248,10 @@ module Dry
         # @return [String]
         def to_s = "None"
         alias_method :inspect, :to_s
+
+        def pretty_print(pp)
+          pp.text "None"
+        end
 
         # @api private
         def eql?(other) = other.is_a?(None)

--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -116,6 +116,17 @@ module Dry
         end
         alias_method :inspect, :to_s
 
+        def pretty_print(pp)
+          pp.text "Success("
+          unless Unit.equal?(@value)
+            pp.group(1) do
+              pp.breakable("")
+              pp.pp(@value)
+            end
+          end
+          pp.text ")"
+        end
+
         # Transforms to a Failure instance
         #
         # @return [Result::Failure]
@@ -226,6 +237,17 @@ module Dry
           end
         end
         alias_method :inspect, :to_s
+
+        def pretty_print(pp)
+          pp.text "Failure("
+          unless Unit.equal?(@value)
+            pp.group(1) do
+              pp.breakable("")
+              pp.pp(@value)
+            end
+          end
+          pp.text ")"
+        end
 
         # Transform to a Success instance
         #

--- a/spec/unit/maybe_spec.rb
+++ b/spec/unit/maybe_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe(Dry::Monads::Maybe) do
       expect(subject.inspect).to eql('Some("foo")')
     end
 
+    it "pretty prints" do
+      out = +""
+      PP.pp(subject, out)
+      expect(out).to eql(%{Some("foo")\n})
+
+      out = +""
+      PP.pp(some[unit], out)
+      expect(out).to eql("Some()\n")
+    end
+
     describe ".to_proc" do
       it "returns a constructor block" do
         expect(maybe::Some.to_proc.("foo")).to eql(subject)
@@ -303,6 +313,12 @@ RSpec.describe(Dry::Monads::Maybe) do
 
     it "has custom inspection" do
       expect(subject.inspect).to eql("None")
+    end
+
+    it "pretty prints" do
+      out = +""
+      PP.pp(subject, out)
+      expect(out).to eql(%(None\n))
     end
 
     describe ".missing_method" do

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe(Dry::Monads::Result) do
       expect(subject.inspect).to eql('Success("foo")')
     end
 
+    it "pretty prints" do
+      out = +""
+      PP.pp(subject, out)
+      expect(out).to eql(%{Success("foo")\n})
+
+      out = +""
+      PP.pp(success[unit], out)
+      expect(out).to eql("Success()\n")
+    end
+
     describe ".[]" do
       it "builds a Success with an array" do
         expect(described_class[:found, 1]).to eql(success[[:found, 1]])
@@ -349,6 +359,16 @@ RSpec.describe(Dry::Monads::Result) do
 
     it "has custom inspection" do
       expect(subject.inspect).to eql('Failure("bar")')
+    end
+
+    it "pretty prints" do
+      out = +""
+      PP.pp(subject, out)
+      expect(out).to eql(%{Failure("bar")\n})
+
+      out = +""
+      PP.pp(failure[unit], out)
+      expect(out).to eql("Failure()\n")
     end
 
     describe ".[]" do


### PR DESCRIPTION
Adds `#pretty_print` to Result and Maybe, so [PP](https://docs.ruby-lang.org/en/master/PP.html) looks good.

Examples:

```
>> pp M::Success()
Success()

>> pp M::Success(User.first)
Success(
 #<User:0x00007f414e3584a0
  id: 1,
  email: [FILTERED],
  name: "Paul",
  staff: true,
  automated_actor: false,
  settings: {},
  auth_uid: nil,
  auth_profile: nil,
  created_at: "2025-05-13 21:34:12.784955000 +0000",
  updated_at: "2025-05-13 21:34:12.784955000 +0000",
  discarded_at: nil>)

>> pp result.to_monad
Failure(
 #<Dry::Validation::Result
 {now: 2025-05-16 14:52:40.354675084 UTC +00:00}
 errors={chat: ["is missing"], user: ["is missing"], user_message: ["is missing"]}>)

>> pp M::Some(User.first)
Some(
 #<User:0x00007f414e35a8e0
  id: 1,
  email: [FILTERED],
  name: "Paul Sadauskas",
  staff: true,
  automated_actor: false,
  settings: {},
  auth_uid: nil,
  auth_profile: nil,
  created_at: "2025-05-13 21:34:12.784955000 +0000",
  updated_at: "2025-05-13 21:34:12.784955000 +0000",
  discarded_at: nil>)

>> pp M::None()
None
```

Also, Pry and IRB leverage PP for their output, and even can color it, so this lets it color the monads, and the contents of the monads:

Before:

![image](https://github.com/user-attachments/assets/760bf5fe-82cf-416a-9832-0a3151b50bd5)

After:

![image](https://github.com/user-attachments/assets/d78697f3-8013-4b91-8895-e2c96bb8e2ff)
