### PR TITLE
Fix detection of RSpec context when debug_inspector is not available

### DIFF
--- a/lib/dry/monads/extensions/rspec.rb
+++ b/lib/dry/monads/extensions/rspec.rb
@@ -159,6 +159,37 @@ module Dry
             ::Dry::Monads::List
           end
         end
+
+        def rspec_example_context?(location)
+          example_group_instance = ::RSpec.current_example&.example_group_instance
+          return false unless example_group_instance
+
+          spec_example_block?(location) || example_group_method?(example_group_instance, location)
+        end
+
+        private
+
+        def spec_example_block?(location)
+          location.path.end_with?("_spec.rb") && location.label.include?("block")
+        end
+
+        def example_group_method?(example_group_instance, location)
+          method_name = caller_method_name(location)
+          return false unless method_name
+
+          owner = example_group_instance.method(method_name).owner
+
+          ![::BasicObject, ::Kernel, ::Object].include?(owner)
+        rescue NameError
+          false
+        end
+
+        def caller_method_name(location)
+          label = location.label.to_s
+          return nil if label.include?("block")
+
+          label.split(/[.#]/).last&.to_sym
+        end
       end
     end
   end
@@ -185,7 +216,7 @@ catch_missing_const = Module.new do
     def const_missing(name)
       const_name = Dry::Monads::RSpec.resolve_constant_name(name)
 
-      if const_name && caller_locations(1, 1).first.path.end_with?("_spec.rb")
+      if const_name && Dry::Monads::RSpec.rspec_example_context?(caller_locations(1, 1).first)
         Dry::Monads::RSpec.name_to_const(const_name)
       else
         super


### PR DESCRIPTION
Dry Monad's RSpec extension has two paths when allowing for missing constants: one uses debug_inspector to check if we are in the context of RSpec example to allow missing consts. This works in CRuby (MRI), but not in JRuby.

The fallback branch just had a check if there is a file matching `*_spec.rb` in the call stack. But since this is only run from the context of RSpec, there is always such file there. This yielded a lot of false positives.

This PR tries to replace this faulty check with more elaborate one, based on `RSpec.current_example.example_group_instance`.