### PR TITLE
Fix be_* matchers in RSpec extension on JRuby

### DIFF
--- a/lib/dry/monads/extensions/rspec.rb
+++ b/lib/dry/monads/extensions/rspec.rb
@@ -49,8 +49,9 @@ module Dry
             c.split("::").last
           end
 
-          matcher :"be_#{name}" do |expected = Undefined|
+          matcher :"be_#{name}" do |*expected_args|
             predicate = "#{name}?"
+            expected = expected_args.fetch(0, Undefined)
 
             match do |actual|
               if expected_classes.any? { |klass| actual.is_a?(klass) }


### PR DESCRIPTION
This works around a bug in JRuby that causes unnecessary destructuring when block argument is an array and there is a default value.

See https://github.com/jruby/jruby/issues/9375 - we can revert the workaround once the fix is merged upstream and released.