### PR TITLE
Create temp spec files with realistic filename

### DIFF
--- a/spec/extensions/super_diff_spec.rb
+++ b/spec/extensions/super_diff_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "super_diff"
+require "tempfile"
 
 RSpec.describe "SuperDiff extension" do
   let(:output_start_marker) do
@@ -12,7 +13,7 @@ RSpec.describe "SuperDiff extension" do
   end
 
   def run_spec(code)
-    temp_spec = Tempfile.new(["failing_spec", ".rb"])
+    temp_spec = Tempfile.new(["failing", "_spec.rb"])
     temp_spec.write(<<~RUBY)
       require "dry/monads"
 


### PR DESCRIPTION
In absence of debug_inspector we are still relying on the file having the `_spec.rb `part in the filename. However, temp files for `super_diff` specs were missing that, which caused RSpec extension to misinterpret what's going on. Giving these temp files a proper name fixes the tests on JRuby.