### PR TITLE
docs: fix typo `sucessful` → `successful` in task.html.md

### DIFF
--- a/docsite/source/task.html.md
+++ b/docsite/source/task.html.md
@@ -97,7 +97,7 @@ Task[:immediate] { 1/0 }.or_fmap { 0 } # => Task(value=0)
 
 ### Extracting result
 
-Getting the result of a task is an unsafe operation, it blocks the current thread until the task is finished, then returns the value or raises an exception if the evaluation wasn't sucessful. It effectively cancels all niceties of tasks so you shouldn't use it in production code.
+Getting the result of a task is an unsafe operation, it blocks the current thread until the task is finished, then returns the value or raises an exception if the evaluation wasn't successful. It effectively cancels all niceties of tasks so you shouldn't use it in production code.
 
 ```ruby
 Task { 0 }.value! # => 0


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `docsite/source/task.html.md` (line ~100)
- Change: `sucessful` → `successful`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
