### PR TITLE
docs: fix typo `Tranforms` → `Transforms` in task.rb

### DIFF
--- a/lib/dry/monads/task.rb
+++ b/lib/dry/monads/task.rb
@@ -140,7 +140,7 @@ module Dry
       end
       alias_method :inspect, :to_s
 
-      # Tranforms the error if the computation wasn't successful.
+      # Transforms the error if the computation wasn't successful.
       #
       # @param block [Proc]
       # @return [Task]


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `lib/dry/monads/task.rb` (line ~143)
- Change: `Tranforms` → `Transforms`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
