### PR TITLE
docs: fix typo `noticable` → `noticeable` in tracing-failures.html.md

### DIFF
--- a/docsite/source/tracing-failures.html.md
+++ b/docsite/source/tracing-failures.html.md
@@ -6,7 +6,7 @@ name: dry-monads
 
 "Left" values of right-biased monads like `Maybe` and `Result` (as in, `None()` and `Failure()`) ignore blocks passed to `fmap` and `bind`. Because of this, these values travel across the application without any modification. If the place where a `Failure` was constructed is burried somewhere deep in the app or library code it may be pretty hard to find out where exactly the error occurred.
 
-This is a noticable downside compared to "good" old exceptions. To address it, every `Failure(...)` and `None()` value tracks the line where it was created:
+This is a noticeable downside compared to "good" old exceptions. To address it, every `Failure(...)` and `None()` value tracks the line where it was created:
 
 ```ruby
 # create_user.rb


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `docsite/source/tracing-failures.html.md` (line ~9)
- Change: `noticable` → `noticeable`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
